### PR TITLE
Future-proof the api

### DIFF
--- a/doc/libportal-sections.txt
+++ b/doc/libportal-sections.txt
@@ -16,6 +16,7 @@ xdp_parent_new_gtk
 
 <SECTION>
 <FILE>screenshot</FILE>
+XdpScreenshotFlags
 xdp_portal_take_screenshot
 xdp_portal_take_screenshot_finish
 xdp_portal_pick_color
@@ -24,6 +25,7 @@ xdp_portal_pick_color_finish
 
 <SECTION>
 <FILE>notification</FILE>
+XdpNotificationFlags
 xdp_portal_add_notification
 xdp_portal_add_notification_finish
 xdp_portal_remove_notification
@@ -31,18 +33,21 @@ xdp_portal_remove_notification
 
 <SECTION>
 <FILE>email</FILE>
+XdpEmailFlags
 xdp_portal_compose_email
 xdp_portal_compose_email_finish
 </SECTION>
 
 <SECTION>
 <FILE>background</FILE>
+XdpBackgroundFlags
 xdp_portal_request_background
 xdp_portal_request_background_finish
 </SECTION>
 
 <SECTION>
 <FILE>account</FILE>
+XdpUserInformationFlags
 xdp_portal_get_user_information
 xdp_portal_get_user_information_finish
 </SECTION>
@@ -50,10 +55,11 @@ xdp_portal_get_user_information_finish
 <SECTION>
 <FILE>inhibit</FILE>
 XdpInhibitFlags
-XdpLoginSessionState
+XdpSessionState
 xdp_portal_session_inhibit
 xdp_portal_session_inhibit_finish
 xdp_portal_session_uninhibit
+XdpSessionMonitorFlags
 xdp_portal_session_monitor_start
 xdp_portal_session_monitor_start_finish
 xdp_portal_session_monitor_stop
@@ -62,6 +68,7 @@ xdp_portal_session_monitor_query_end_response
 
 <SECTION>
 <FILE>open</FILE>
+XdpOpenUriFlags
 xdp_portal_open_uri
 xdp_portal_open_uri_finish
 xdp_portal_open_directory
@@ -70,8 +77,10 @@ xdp_portal_open_directory_finish
 
 <SECTION>
 <FILE>filechooser</FILE>
+XdpOpenFileFlags
 xdp_portal_open_file
 xdp_portal_open_file_finish
+XdpSaveFileFlags
 xdp_portal_save_file
 xdp_portal_save_file_finish
 xdp_portal_save_files
@@ -86,6 +95,7 @@ xdp_portal_trash_file_finish
 
 <SECTION>
 <FILE>print</FILE>
+XdpPrintFlags
 xdp_portal_prepare_print
 xdp_portal_prepare_print_finish
 xdp_portal_print_file
@@ -113,8 +123,7 @@ xdp_session_get_type
 <SECTION>
 <FILE>screencast</FILE>
 XdpOutputType
-XDP_OUTPUT_NONE
-XDP_OUTPUT_ALL
+XdpScreenCastFlags
 xdp_portal_create_screencast_session
 xdp_portal_create_screencast_session_finish
 </SECTION>
@@ -122,8 +131,7 @@ xdp_portal_create_screencast_session_finish
 <SECTION>
 <FILE>remote</FILE>
 XdpDeviceType
-XDP_DEVICE_NONE
-XDP_DEVICE_ALL
+XdpRemoteDesktopFlags
 xdp_portal_create_remote_desktop_session
 xdp_portal_create_remote_desktop_session_finish
 xdp_session_pointer_motion
@@ -142,6 +150,7 @@ xdp_session_touch_up
 
 <SECTION>
 <FILE>camera</FILE>
+XdpCameraFlags
 xdp_portal_is_camera_present
 xdp_portal_access_camera
 xdp_portal_access_camera_finish
@@ -151,6 +160,7 @@ xdp_portal_open_pipewire_remote_for_camera
 <SECTION>
 <FILE>location</FILE>
 XdpLocationAccuracy
+XdpLocationMonitorFlags
 xdp_portal_location_monitor_start
 xdp_portal_location_monitor_start_finish
 xdp_portal_location_monitor_stop
@@ -167,16 +177,18 @@ xdp_portal_spawn_signal
 <SECTION>
 <FILE>updates</FILE>
 XdpUpdateStatus
+XdpUpdateMonitorFlags
 xdp_portal_update_monitor_start
 xdp_portal_update_monitor_start_finish
 xdp_portal_update_monitor_stop
+XdpUpdateInstallFlags
 xdp_portal_update_install
 xdp_portal_update_install_finish
 </SECTION>
 
 <SECTION>
 <FILE>wallpaper</FILE>
-XdpWallpaperTarget
+XdpWallpaperFlags
 xdp_portal_set_wallpaper
 xdp_portal_set_wallpaper_finish
 </SECTION>

--- a/libportal/account.c
+++ b/libportal/account.c
@@ -207,6 +207,7 @@ get_user_information (AccountCall *call)
  * @parent: (nullable): parent window information
  * @reason: (nullable) a string that can be shown in the dialog to explain
  *    why the information is needed
+ * @flags: options for this call
  * @cancellable: (nullable): optional #GCancellable
  * @callback: (scope async): a callback to call when the request is done
  * @data: (closure): data to pass to @callback
@@ -220,6 +221,7 @@ void
 xdp_portal_get_user_information (XdpPortal *portal,
                                  XdpParent *parent,
                                  const char *reason,
+                                 XdpUserInformationFlags flags,
                                  GCancellable *cancellable,
                                  GAsyncReadyCallback  callback,
                                  gpointer data)
@@ -227,6 +229,7 @@ xdp_portal_get_user_information (XdpPortal *portal,
   AccountCall *call = NULL;
 
   g_return_if_fail (XDP_IS_PORTAL (portal));
+  g_return_if_fail (flags == XDP_USER_INFORMATION_FLAG_NONE);
 
   call = g_new0 (AccountCall, 1);
   call->portal = g_object_ref (portal);

--- a/libportal/account.h
+++ b/libportal/account.h
@@ -21,17 +21,22 @@
 
 G_BEGIN_DECLS
 
-XDP_PUBLIC
-void       xdp_portal_get_user_information        (XdpPortal            *portal,
-                                                   XdpParent            *parent,
-                                                   const char           *reason,
-                                                   GCancellable         *cancellable,
-                                                   GAsyncReadyCallback   callback,
-                                                   gpointer              data);
+typedef enum {
+  XDP_USER_INFORMATION_FLAG_NONE = 0
+} XdpUserInformationFlags;
 
 XDP_PUBLIC
-GVariant * xdp_portal_get_user_information_finish (XdpPortal            *portal,
-                                                   GAsyncResult         *result,
-                                                   GError              **error);
+void       xdp_portal_get_user_information        (XdpPortal                *portal,
+                                                   XdpParent                *parent,
+                                                   const char               *reason,
+                                                   XdpUserInformationFlags   flags,
+                                                   GCancellable             *cancellable,
+                                                   GAsyncReadyCallback       callback,
+                                                   gpointer                  data);
+
+XDP_PUBLIC
+GVariant * xdp_portal_get_user_information_finish (XdpPortal                *portal,
+                                                   GAsyncResult             *result,
+                                                   GError                  **error);
 
 G_END_DECLS

--- a/libportal/background.h
+++ b/libportal/background.h
@@ -21,21 +21,34 @@
 
 G_BEGIN_DECLS
 
+/**
+ * XdpBackgroundFlags:
+ * @XDP_BACKGROUND_FLAG_NONE: No options
+ * @XDP_BACKGROUND_FLAG_AUTOSTART: Request autostart as well
+ * @XDP_BACKGROUND_FLAG_ACTIVATABLE: Whether the application is D-Bus-activatable
+ *
+ * Options to use when requesting background.
+ */
+typedef enum {
+  XDP_BACKGROUND_FLAG_NONE        = 0,
+  XDP_BACKGROUND_FLAG_AUTOSTART   = 1 << 0,
+  XDP_BACKGROUND_FLAG_ACTIVATABLE = 1 << 1
+} XdpBackgroundFlags;
+
 XDP_PUBLIC
 void      xdp_portal_request_background         (XdpPortal           *portal,
                                                  XdpParent           *parent,
-                                                 GPtrArray           *commandline,
                                                  char                *reason,
-                                                 gboolean             autostart,
-                                                 gboolean             dbus_activatable,
+                                                 GPtrArray           *commandline,
+                                                 XdpBackgroundFlags   flags,
                                                  GCancellable        *cancellable,
                                                  GAsyncReadyCallback  callback,
                                                  gpointer             user_data);
 
 XDP_PUBLIC
-gboolean   xdp_portal_request_background_finish (XdpPortal     *portal,
-                                                 GAsyncResult  *result,
-                                                 GError       **error);
+gboolean   xdp_portal_request_background_finish (XdpPortal           *portal,
+                                                 GAsyncResult        *result,
+                                                 GError             **error);
 
 
 G_END_DECLS

--- a/libportal/camera.c
+++ b/libportal/camera.c
@@ -215,6 +215,7 @@ g_debug ("Calling AccessCamera");
  * xdp_portal_access_camera:
  * @portal: a #XdpPortal
  * @parent: (nullable): parent window information
+ * @flags: options for this call
  * @cancellable: (nullable): optional #GCancellable
  * @callback: (scope async): a callback to call when the request is done
  * @data: (closure): data to pass to @callback
@@ -228,6 +229,7 @@ g_debug ("Calling AccessCamera");
 void
 xdp_portal_access_camera (XdpPortal           *portal,
                           XdpParent           *parent,
+                          XdpCameraFlags       flags,
                           GCancellable        *cancellable,
                           GAsyncReadyCallback  callback,
                           gpointer             data)
@@ -235,6 +237,7 @@ xdp_portal_access_camera (XdpPortal           *portal,
   AccessCameraCall *call;
 
   g_return_if_fail (XDP_IS_PORTAL (portal));
+  g_return_if_fail (flags == XDP_CAMERA_FLAG_NONE);
 
   call = g_new0 (AccessCameraCall, 1);
   call->portal = g_object_ref (portal);

--- a/libportal/camera.h
+++ b/libportal/camera.h
@@ -24,17 +24,22 @@ G_BEGIN_DECLS
 XDP_PUBLIC
 gboolean  xdp_portal_is_camera_present   (XdpPortal            *portal);
 
-XDP_PUBLIC
-void      xdp_portal_access_camera       (XdpPortal            *portal,
-                                          XdpParent            *parent,
-                                          GCancellable         *cancellable,
-                                          GAsyncReadyCallback   callback,
-                                          gpointer              data);
+typedef enum {
+  XDP_CAMERA_FLAG_NONE = 0
+} XdpCameraFlags;
 
 XDP_PUBLIC
-gboolean xdp_portal_access_camera_finish (XdpPortal            *portal,
-                                          GAsyncResult         *result,
-                                          GError              **error);
+void      xdp_portal_access_camera       (XdpPortal           *portal,
+                                          XdpParent           *parent,
+                                          XdpCameraFlags       flags,
+                                          GCancellable        *cancellable,
+                                          GAsyncReadyCallback  callback,
+                                          gpointer             data);
+
+XDP_PUBLIC
+gboolean xdp_portal_access_camera_finish (XdpPortal           *portal,
+                                          GAsyncResult        *result,
+                                          GError             **error);
 
 XDP_PUBLIC
 int      xdp_portal_open_pipewire_remote_for_camera (XdpPortal *portal);

--- a/libportal/email.c
+++ b/libportal/email.c
@@ -307,6 +307,7 @@ compose_email (EmailCall *call)
  * @subject: (nullable): the subject for the email
  * @body: (nullable): the body for the email
  * @attachments: (nullable): an array of paths for files to attach
+ * @flags: options for this call
  * @cancellable: (nullable): optional #GCancellable
  * @callback: (scope async): a callback to call when the request is done
  * @data: (closure): data to pass to @callback
@@ -326,6 +327,7 @@ xdp_portal_compose_email (XdpPortal *portal,
                           const char *subject,
                           const char *body,
                           const char *const *attachments,
+                          XdpEmailFlags flags,
                           GCancellable *cancellable,
                           GAsyncReadyCallback  callback,
                           gpointer data)
@@ -333,6 +335,7 @@ xdp_portal_compose_email (XdpPortal *portal,
   EmailCall *call;
 
   g_return_if_fail (XDP_IS_PORTAL (portal));
+  g_return_if_fail (flags == XDP_EMAIL_FLAG_NONE);
 
   call = g_new0 (EmailCall, 1);
   call->portal = g_object_ref (portal);

--- a/libportal/email.h
+++ b/libportal/email.h
@@ -21,6 +21,10 @@
 
 G_BEGIN_DECLS
 
+typedef enum {
+  XDP_EMAIL_FLAG_NONE = 0
+} XdpEmailFlags;
+
 XDP_PUBLIC
 void       xdp_portal_compose_email        (XdpPortal            *portal,
                                             XdpParent            *parent,
@@ -30,6 +34,7 @@ void       xdp_portal_compose_email        (XdpPortal            *portal,
                                             const char           *subject,
                                             const char           *body,
                                             const char *const    *attachments,
+                                            XdpEmailFlags         flags,
                                             GCancellable         *cancellable,
                                             GAsyncReadyCallback   callback,
                                             gpointer              data);

--- a/libportal/filechooser.h
+++ b/libportal/filechooser.h
@@ -21,15 +21,26 @@
 
 G_BEGIN_DECLS
 
+/**
+ * XdpOpenFileFlags:
+ * @XDP_OPEN_FILE_FLAG_NONE: No options
+ * @XDP_OPEN_FILE_FLAG_MULTIPLE: Allow selecting multiple files
+ *
+ * Options for opening files.
+ */
+typedef enum {
+  XDP_OPEN_FILE_FLAG_NONE     = 0,
+  XDP_OPEN_FILE_FLAG_MULTIPLE = 1 << 0,
+} XdpOpenFileFlags;
+
 XDP_PUBLIC
 void       xdp_portal_open_file                   (XdpPortal            *portal,
                                                    XdpParent            *parent,
                                                    const char           *title,
-                                                   gboolean              modal,
-                                                   gboolean              multiple,
                                                    GVariant             *filters,
                                                    GVariant             *current_filter,
                                                    GVariant             *choices,
+                                                   XdpOpenFileFlags      flags,
                                                    GCancellable         *cancellable,
                                                    GAsyncReadyCallback   callback,
                                                    gpointer              data);
@@ -39,17 +50,21 @@ GVariant *xdp_portal_open_file_finish             (XdpPortal            *portal,
                                                    GAsyncResult         *result,
                                                    GError              **error);
 
+typedef enum {
+  XDP_SAVE_FILE_FLAG_NONE = 0
+} XdpSaveFileFlags;
+
 XDP_PUBLIC
 void       xdp_portal_save_file                   (XdpPortal            *portal,
                                                    XdpParent            *parent,
                                                    const char           *title,
-                                                   gboolean              modal,
                                                    const char           *current_name,
                                                    const char           *current_folder,
                                                    const char           *current_file,
                                                    GVariant             *filters,
                                                    GVariant             *current_filter,
                                                    GVariant             *choices,
+                                                   XdpSaveFileFlags      flags,
                                                    GCancellable         *cancellable,
                                                    GAsyncReadyCallback   callback,
                                                    gpointer              data);
@@ -63,11 +78,11 @@ XDP_PUBLIC
 void       xdp_portal_save_files                  (XdpPortal            *portal,
                                                    XdpParent            *parent,
                                                    const char           *title,
-                                                   gboolean              modal,
                                                    const char           *current_name,
                                                    const char           *current_folder,
                                                    GVariant             *files,
                                                    GVariant             *choices,
+                                                   XdpSaveFileFlags      flags,
                                                    GCancellable         *cancellable,
                                                    GAsyncReadyCallback   callback,
                                                    gpointer              data);

--- a/libportal/inhibit.c
+++ b/libportal/inhibit.c
@@ -213,8 +213,8 @@ do_inhibit (InhibitCall *call)
  * xdp_portal_session_inhibit:
  * @portal: a #XdpPortal
  * @parent: (nullable): parent window information
- * @inhibit: information about what to inhibit
  * @reason: (nullable): user-visible reason for the inhibition
+ * @flags: information about what to inhibit
  * @cancellable: (nullable): optional #GCancellable
  * @callback: (scope async): a callback to call when the request is done
  * @data: (closure): data to pass to @callback
@@ -230,8 +230,8 @@ do_inhibit (InhibitCall *call)
 void
 xdp_portal_session_inhibit (XdpPortal            *portal,
                             XdpParent            *parent,
-                            XdpInhibitFlags       inhibit,
                             const char           *reason,
+                            XdpInhibitFlags       flags,
                             GCancellable         *cancellable,
                             GAsyncReadyCallback   callback,
                             gpointer              data)
@@ -239,6 +239,10 @@ xdp_portal_session_inhibit (XdpPortal            *portal,
   InhibitCall *call = NULL;
 
   g_return_if_fail (XDP_IS_PORTAL (portal));
+  g_return_if_fail ((flags & ~(XDP_INHIBIT_FLAG_LOGOUT |
+                               XDP_INHIBIT_FLAG_USER_SWITCH |
+                               XDP_INHIBIT_FLAG_SUSPEND |
+                               XDP_INHIBIT_FLAG_IDLE)) == 0);
 
   if (portal->inhibit_handles == NULL)
     portal->inhibit_handles = g_hash_table_new_full (NULL, NULL, NULL, g_free);
@@ -253,7 +257,7 @@ xdp_portal_session_inhibit (XdpPortal            *portal,
     call->parent = _xdp_parent_copy (parent);
   else
     call->parent_handle = g_strdup ("");
-  call->inhibit = inhibit;
+  call->inhibit = flags;
   call->id = portal->next_inhibit_id;
   call->reason = g_strdup (reason);
   call->task = g_task_new (portal, cancellable, callback, data);
@@ -554,6 +558,7 @@ create_monitor (CreateMonitorCall *call)
  * xdp_portal_session_monitor_start:
  * @portal: a #XdpPortal
  * @parent: (nullable): a XdpParent, or %NULL
+ * @flags: options for this call
  * @cancellable: (nullable): optional #GCancellable
  * @callback: (scope async): a callback to call when the request is done
  * @data: (closure): data to pass to @callback
@@ -568,6 +573,7 @@ create_monitor (CreateMonitorCall *call)
 void
 xdp_portal_session_monitor_start (XdpPortal *portal,
                                   XdpParent *parent,
+                                  XdpSessionMonitorFlags flags,
                                   GCancellable *cancellable,
                                   GAsyncReadyCallback callback,
                                   gpointer data)
@@ -576,6 +582,7 @@ xdp_portal_session_monitor_start (XdpPortal *portal,
   CreateMonitorCall *call;
 
   g_return_if_fail (XDP_IS_PORTAL (portal));
+  g_return_if_fail (flags == XDP_SESSION_MONITOR_FLAG_NONE);
 
   call = g_new0 (CreateMonitorCall, 1);
   call->portal = g_object_ref (portal);

--- a/libportal/inhibit.h
+++ b/libportal/inhibit.h
@@ -23,33 +23,33 @@ G_BEGIN_DECLS
 
 /**
  * XdpInhibitFlags:
- * @XDP_INHIBIT_LOGOUT: Inhibit logout.
- * @XDP_INHIBIT_USER_SWITCH: Inhibit user switching.
- * @XDP_INHIBIT_SUSPEND: Inhibit suspend.
- * @XDP_INHIBIT_IDLE: Inhibit the session going idle.
+ * @XDP_INHIBIT_FLAG_LOGOUT: Inhibit logout
+ * @XDP_INHIBIT_FLAG_USER_SWITCH: Inhibit user switching
+ * @XDP_INHIBIT_FLAG_SUSPEND: Inhibit suspend
+ * @XDP_INHIBIT_FLAG_IDLE: Inhibit the session going idle
  *
  * Flags that determine what session status changes are inhibited.
  */
 typedef enum {
-  XDP_INHIBIT_LOGOUT      = 1,
-  XDP_INHIBIT_USER_SWITCH = 2,
-  XDP_INHIBIT_SUSPEND     = 4,
-  XDP_INHIBIT_IDLE        = 8
+  XDP_INHIBIT_FLAG_LOGOUT      = 1 << 0,
+  XDP_INHIBIT_FLAG_USER_SWITCH = 1 << 1,
+  XDP_INHIBIT_FLAG_SUSPEND     = 1 << 2,
+  XDP_INHIBIT_FLAG_IDLE        = 1 << 3
 } XdpInhibitFlags;
 
 XDP_PUBLIC
 void       xdp_portal_session_inhibit             (XdpPortal            *portal,
                                                    XdpParent            *parent,
-                                                   XdpInhibitFlags       inhibit,
                                                    const char           *reason,
+                                                   XdpInhibitFlags       inhibit,
                                                    GCancellable         *cancellable,
                                                    GAsyncReadyCallback   callback,
                                                    gpointer              data);
 
 XDP_PUBLIC
-int        xdp_portal_session_inhibit_finish      (XdpPortal           *portal,
-                                                   GAsyncResult        *result,
-                                                   GError             **error);
+int        xdp_portal_session_inhibit_finish      (XdpPortal            *portal,
+                                                   GAsyncResult         *result,
+                                                   GError              **error);
 
 XDP_PUBLIC
 void       xdp_portal_session_uninhibit           (XdpPortal            *portal,
@@ -72,22 +72,27 @@ typedef enum {
   XDP_LOGIN_SESSION_ENDING =    3,
 } XdpLoginSessionState;
 
-XDP_PUBLIC
-void       xdp_portal_session_monitor_start              (XdpPortal            *portal,
-                                                          XdpParent            *parent,
-                                                          GCancellable         *cancellable,
-                                                          GAsyncReadyCallback   callback,
-                                                          gpointer              data);
+typedef enum {
+  XDP_SESSION_MONITOR_FLAG_NONE = 0
+} XdpSessionMonitorFlags;
 
 XDP_PUBLIC
-gboolean   xdp_portal_session_monitor_start_finish       (XdpPortal            *portal,
-                                                          GAsyncResult         *result,
-                                                          GError              **error);
+void       xdp_portal_session_monitor_start              (XdpPortal               *portal,
+                                                          XdpParent               *parent,
+                                                          XdpSessionMonitorFlags   flags,
+                                                          GCancellable            *cancellable,
+                                                          GAsyncReadyCallback      callback,
+                                                          gpointer                 data);
 
 XDP_PUBLIC
-void       xdp_portal_session_monitor_stop               (XdpPortal            *portal);
+gboolean   xdp_portal_session_monitor_start_finish       (XdpPortal               *portal,
+                                                          GAsyncResult            *result,
+                                                          GError                 **error);
 
 XDP_PUBLIC
-void       xdp_portal_session_monitor_query_end_response (XdpPortal            *portal);
+void       xdp_portal_session_monitor_stop               (XdpPortal               *portal);
+
+XDP_PUBLIC
+void       xdp_portal_session_monitor_query_end_response (XdpPortal               *portal);
 
 G_END_DECLS

--- a/libportal/location.c
+++ b/libportal/location.c
@@ -311,6 +311,7 @@ create_session (CreateCall *call)
  * @distance_threshold: distance threshold, in meters
  * @time_threshold: time threshold, in seconds
  * @accuracy: desired accuracy
+ * @flags: options for this call
  * @cancellable: (nullable): optional #GCancellable
  * @callback: (scope async): a callback to call when the request is done
  * @data: (closure): data to pass to @callback
@@ -334,6 +335,7 @@ xdp_portal_location_monitor_start (XdpPortal *portal,
                                    guint distance_threshold,
                                    guint time_threshold,
                                    XdpLocationAccuracy accuracy,
+                                   XdpLocationMonitorFlags flags,
                                    GCancellable *cancellable,
                                    GAsyncReadyCallback callback,
                                    gpointer data)
@@ -341,6 +343,7 @@ xdp_portal_location_monitor_start (XdpPortal *portal,
   CreateCall *call;
 
   g_return_if_fail (XDP_IS_PORTAL (portal));
+  g_return_if_fail (flags == XDP_LOCATION_MONITOR_FLAG_NONE);
 
   call = g_new0 (CreateCall, 1);
   call->portal = g_object_ref (portal);

--- a/libportal/location.h
+++ b/libportal/location.h
@@ -42,22 +42,27 @@ typedef enum {
   XDP_LOCATION_ACCURACY_EXACT
 } XdpLocationAccuracy;
 
-XDP_PUBLIC
-void     xdp_portal_location_monitor_start        (XdpPortal            *portal,
-                                                   XdpParent            *parent,
-                                                   guint                 distance_threshold,
-                                                   guint                 time_threshold,
-                                                   XdpLocationAccuracy   accuracy,
-                                                   GCancellable         *cancellable,
-                                                   GAsyncReadyCallback   callback,
-                                                   gpointer              data);
+typedef enum {
+  XDP_LOCATION_MONITOR_FLAG_NONE = 0
+} XdpLocationMonitorFlags;
 
 XDP_PUBLIC
-gboolean xdp_portal_location_monitor_start_finish (XdpPortal            *portal,
-                                                   GAsyncResult         *result,
-                                                   GError              **error);
+void     xdp_portal_location_monitor_start        (XdpPortal                *portal,
+                                                   XdpParent                *parent,
+                                                   guint                     distance_threshold,
+                                                   guint                     time_threshold,
+                                                   XdpLocationAccuracy       accuracy,
+                                                   XdpLocationMonitorFlags   flags,
+                                                   GCancellable             *cancellable,
+                                                   GAsyncReadyCallback       callback,
+                                                   gpointer                  data);
 
 XDP_PUBLIC
-void     xdp_portal_location_monitor_stop         (XdpPortal            *portal);
+gboolean xdp_portal_location_monitor_start_finish (XdpPortal                *portal,
+                                                   GAsyncResult             *result,
+                                                   GError                  **error);
+
+XDP_PUBLIC
+void     xdp_portal_location_monitor_stop         (XdpPortal                *portal);
 
 G_END_DECLS

--- a/libportal/notification.c
+++ b/libportal/notification.c
@@ -92,6 +92,7 @@ call_done (GObject *source,
  * @portal: a #XdpPortal
  * @id: unique ID for the notification
  * @notification: a #GVariant dictionary with the content of the notification
+ * @flags: options for this call
  * @cancellable: (nullable): optional #GCancellable
  * @callback: (scope async): a callback to call when the request is done
  * @data: (closure): data to pass to @callback
@@ -127,16 +128,19 @@ call_done (GObject *source,
  * To withdraw a notification, use xdp_portal_remove_notification().
  */
 void
-xdp_portal_add_notification (XdpPortal           *portal,
-                             const char          *id,
-                             GVariant            *notification,
-                             GCancellable        *cancellable,
-                             GAsyncReadyCallback  callback,
-                             gpointer             data)
+xdp_portal_add_notification (XdpPortal *portal,
+                             const char *id,
+                             GVariant *notification,
+                             XdpNotificationFlags flags,
+                             GCancellable *cancellable,
+                             GAsyncReadyCallback callback,
+                             gpointer data)
 {
-  g_return_if_fail (XDP_IS_PORTAL (portal));
   GAsyncReadyCallback call_done_cb = NULL;
   CallDoneData *call_done_data = NULL;
+
+  g_return_if_fail (XDP_IS_PORTAL (portal));
+  g_return_if_fail (flags == XDP_NOTIFICATION_FLAG_NONE);
 
   ensure_action_invoked_connection (portal);
 

--- a/libportal/notification.h
+++ b/libportal/notification.h
@@ -21,21 +21,26 @@
 
 G_BEGIN_DECLS
 
-XDP_PUBLIC
-void       xdp_portal_add_notification    (XdpPortal           *portal,
-                                           const char          *id,
-                                           GVariant            *notification,
-                                           GCancellable        *cancellable,
-                                           GAsyncReadyCallback  callback,
-                                           gpointer             data);
+typedef enum {
+  XDP_NOTIFICATION_FLAG_NONE = 0
+} XdpNotificationFlags;
 
 XDP_PUBLIC
-gboolean   xdp_portal_add_notification_finish (XdpPortal    *portal,
-                                               GAsyncResult *result,
-                                               GError       **error);
+void       xdp_portal_add_notification        (XdpPortal             *portal,
+                                               const char            *id,
+                                               GVariant              *notification,
+                                               XdpNotificationFlags   flags,
+                                               GCancellable          *cancellable,
+                                               GAsyncReadyCallback    callback,
+                                               gpointer               data);
 
 XDP_PUBLIC
-void       xdp_portal_remove_notification (XdpPortal  *portal,
-                                           const char *id);
+gboolean   xdp_portal_add_notification_finish (XdpPortal             *portal,
+                                               GAsyncResult          *result,
+                                               GError               **error);
+
+XDP_PUBLIC
+void       xdp_portal_remove_notification     (XdpPortal             *portal,
+                                               const char            *id);
 
 G_END_DECLS

--- a/libportal/openuri.c
+++ b/libportal/openuri.c
@@ -262,8 +262,7 @@ do_open (OpenCall *call)
  * @portal: a #XdpPortal
  * @parent: parent window information
  * @uri: the URI to open
- * @ask: request to show an application chooser
- * @writable: whether to make the file writable
+ * @flags: options for this call
  * @cancellable: (nullable): optional #GCancellable
  * @callback: (scope async): a callback to call when the request is done
  * @data: (closure): data to pass to @callback
@@ -271,18 +270,19 @@ do_open (OpenCall *call)
  * Opens @uri with an external hamdler.
  */
 void
-xdp_portal_open_uri (XdpPortal           *portal,
-                     XdpParent           *parent,
-                     const char          *uri,
-                     gboolean             ask,
-                     gboolean             writable,
-                     GCancellable        *cancellable,
-                     GAsyncReadyCallback  callback,
-                     gpointer             data)
+xdp_portal_open_uri (XdpPortal *portal,
+                     XdpParent *parent,
+                     const char *uri,
+                     XdpOpenUriFlags flags,
+                     GCancellable *cancellable,
+                     GAsyncReadyCallback callback,
+                     gpointer data)
 {
   OpenCall *call = NULL;
 
   g_return_if_fail (XDP_IS_PORTAL (portal));
+  g_return_if_fail ((flags & ~(XDP_OPEN_URI_FLAG_ASK |
+                              XDP_OPEN_URI_FLAG_WRITABLE)) == 0);
 
   call = g_new0 (OpenCall, 1);
   call->portal = g_object_ref (portal);
@@ -291,8 +291,8 @@ xdp_portal_open_uri (XdpPortal           *portal,
   else
     call->parent_handle = g_strdup ("");
   call->uri = g_strdup (uri);
-  call->ask = ask;
-  call->writable = writable;
+  call->ask = (flags & XDP_OPEN_URI_FLAG_ASK) != 0;
+  call->writable = (flags & XDP_OPEN_URI_FLAG_WRITABLE) != 0;
   call->open_dir = FALSE;
   call->task = g_task_new (portal, cancellable, callback, data);
   g_task_set_source_tag (call->task, xdp_portal_open_uri);
@@ -328,7 +328,7 @@ xdp_portal_open_uri_finish (XdpPortal *portal,
  * @portal: a #XdpPortal
  * @parent: parent window information
  * @uri: the URI to open
- * @writable: whether to make the file writable
+ * @flags: options for this call
  * @cancellable: (nullable): optional #GCancellable
  * @callback: (scope async): a callback to call when the request is done
  * @data: (closure): data to pass to @callback
@@ -338,16 +338,18 @@ xdp_portal_open_uri_finish (XdpPortal *portal,
  * to.
  */
 void
-xdp_portal_open_directory (XdpPortal           *portal,
-                           XdpParent           *parent,
-                           const char          *uri,
-                           GCancellable        *cancellable,
-                           GAsyncReadyCallback  callback,
-                           gpointer             data)
+xdp_portal_open_directory (XdpPortal *portal,
+                           XdpParent *parent,
+                           const char *uri,
+                           XdpOpenUriFlags flags,
+                           GCancellable *cancellable,
+                           GAsyncReadyCallback callback,
+                           gpointer data)
 {
   OpenCall *call = NULL;
 
   g_return_if_fail (XDP_IS_PORTAL (portal));
+  g_return_if_fail ((flags & ~(XDP_OPEN_URI_FLAG_ASK)) == 0);
 
   call = g_new0 (OpenCall, 1);
   call->portal = g_object_ref (portal);
@@ -356,7 +358,7 @@ xdp_portal_open_directory (XdpPortal           *portal,
   else
     call->parent_handle = g_strdup ("");
   call->uri = g_strdup (uri);
-  call->ask = FALSE;
+  call->ask = (flags & XDP_OPEN_URI_FLAG_ASK) != 0;
   call->writable = FALSE;
   call->open_dir = TRUE;
   call->task = g_task_new (portal, cancellable, callback, data);

--- a/libportal/openuri.h
+++ b/libportal/openuri.h
@@ -21,12 +21,17 @@
 
 G_BEGIN_DECLS
 
+typedef enum {
+  XDP_OPEN_URI_FLAG_NONE     = 0,
+  XDP_OPEN_URI_FLAG_ASK      = 1 << 0,
+  XDP_OPEN_URI_FLAG_WRITABLE = 1 << 1
+} XdpOpenUriFlags;
+
 XDP_PUBLIC
 void       xdp_portal_open_uri                    (XdpPortal            *portal,
                                                    XdpParent            *parent,
                                                    const char           *uri,
-                                                   gboolean              ask,
-                                                   gboolean              writable,
+                                                   XdpOpenUriFlags       flags,
                                                    GCancellable         *cancellable,
                                                    GAsyncReadyCallback   callback,
                                                    gpointer              data);
@@ -40,6 +45,7 @@ XDP_PUBLIC
 void       xdp_portal_open_directory              (XdpPortal            *portal,
                                                    XdpParent            *parent,
                                                    const char           *uri,
+                                                   XdpOpenUriFlags       flags,
                                                    GCancellable         *cancellable,
                                                    GAsyncReadyCallback   callback,
                                                    gpointer              data);

--- a/libportal/print.c
+++ b/libportal/print.c
@@ -49,7 +49,6 @@ typedef struct {
   XdpParent *parent;
   char *parent_handle;
   char *title;
-  gboolean modal;
   gboolean is_prepare;
   GVariant *settings;
   GVariant *page_setup;
@@ -214,7 +213,6 @@ do_print (PrintCall *call)
 
   g_variant_builder_init (&options, G_VARIANT_TYPE_VARDICT);
   g_variant_builder_add (&options, "{sv}", "handle_token", g_variant_new_string (token));
-  g_variant_builder_add (&options, "{sv}", "modal", g_variant_new_boolean (call->modal));
   if (!call->is_prepare)
     g_variant_builder_add (&options, "{sv}", "token", g_variant_new_uint32 (call->token));
   
@@ -277,9 +275,9 @@ do_print (PrintCall *call)
  * @portal: a #XdpPortal
  * @parent: (nullable): parent window information
  * @title: tile for the print dialog
- * @modal: whether the dialog should be modal
  * @settings: (nullable): Serialized print settings
  * @page_setup: (nullable): Serialized page setup
+ * @flags: options for this call
  * @cancellable: (nullable): optional #GCancellable
  * @callback: (scope async): a callback to call when the request is done
  * @data: (closure): data to pass to @callback
@@ -293,9 +291,9 @@ void
 xdp_portal_prepare_print (XdpPortal *portal,
                           XdpParent *parent,
                           const char *title,
-                          gboolean modal,
                           GVariant *settings,
                           GVariant *page_setup,
+                          XdpPrintFlags flags,
                           GCancellable *cancellable,
                           GAsyncReadyCallback callback,
                           gpointer data)
@@ -303,6 +301,7 @@ xdp_portal_prepare_print (XdpPortal *portal,
   PrintCall *call;
 
   g_return_if_fail (XDP_IS_PORTAL (portal));
+  g_return_if_fail (flags == XDP_PRINT_FLAG_NONE);
 
   call = g_new0 (PrintCall, 1);
   call->portal = g_object_ref (portal);
@@ -311,7 +310,6 @@ xdp_portal_prepare_print (XdpPortal *portal,
   else
     call->parent_handle = g_strdup ("");
   call->title = g_strdup (title);
-  call->modal = modal;
   call->is_prepare = TRUE;
   call->settings = settings ? g_variant_ref (settings) : NULL;
   call->page_setup = page_setup ? g_variant_ref (page_setup) : NULL;
@@ -353,9 +351,9 @@ xdp_portal_prepare_print_finish (XdpPortal *portal,
  * @portal: a #XdpPortal
  * @parent: (nullable): parent window information
  * @title: tile for the print dialog
- * @modal: whether the dialog should be modal
  * @token: token that was returned by a previous xdp_portal_prepare_print() call, or 0
  * @file: path of the document to print
+ * @flags: options for this call
  * @cancellable: (nullable): optional #GCancellable
  * @callback: (scope async): a callback to call when the request is done
  * @data: (closure): data to pass to @callback
@@ -373,9 +371,9 @@ void
 xdp_portal_print_file (XdpPortal *portal,
                        XdpParent *parent,
                        const char *title,
-                       gboolean modal,
                        guint token,
                        const char *file,
+                       XdpPrintFlags flags,
                        GCancellable *cancellable,
                        GAsyncReadyCallback callback,
                        gpointer data)
@@ -383,6 +381,7 @@ xdp_portal_print_file (XdpPortal *portal,
   PrintCall *call;
 
   g_return_if_fail (XDP_IS_PORTAL (portal));
+  g_return_if_fail (flags == XDP_PRINT_FLAG_NONE);
 
   call = g_new0 (PrintCall, 1);
   call->portal = g_object_ref (portal);
@@ -391,7 +390,6 @@ xdp_portal_print_file (XdpPortal *portal,
   else
     call->parent_handle = g_strdup ("");
   call->title = g_strdup (title);
-  call->modal = modal;
   call->is_prepare = FALSE;
   call->token = token;
   call->file = g_strdup (file);

--- a/libportal/print.h
+++ b/libportal/print.h
@@ -21,13 +21,17 @@
 
 G_BEGIN_DECLS
 
+typedef enum {
+  XDP_PRINT_FLAG_NONE = 0
+} XdpPrintFlags;
+
 XDP_PUBLIC
 void      xdp_portal_prepare_print                (XdpPortal            *portal,
                                                    XdpParent            *parent,
                                                    const char           *title,
-                                                   gboolean              modal,
                                                    GVariant             *settings,
                                                    GVariant             *page_setup,
+                                                   XdpPrintFlags         flags,
                                                    GCancellable         *cancellable,
                                                    GAsyncReadyCallback   callback,
                                                    gpointer              data);
@@ -41,9 +45,9 @@ XDP_PUBLIC
 void      xdp_portal_print_file                   (XdpPortal            *portal,
                                                    XdpParent            *parent,
                                                    const char           *title,
-                                                   gboolean              modal,
                                                    guint                 token,
                                                    const char           *file,
+                                                   XdpPrintFlags         flags,
                                                    GCancellable         *cancellable,
                                                    GAsyncReadyCallback   callback,
                                                    gpointer              data);

--- a/libportal/remote.c
+++ b/libportal/remote.c
@@ -339,7 +339,7 @@ create_session (CreateCall *call)
  * xdp_portal_create_screencast_session:
  * @portal: a #XdpPortal
  * @outputs: which kinds of source to offer in the dialog
- * @multiple: whether to allow selecting multiple sources
+ * @flags: options for this call
  * @cancellable: (nullable): optional #GCancellable
  * @callback: (scope async): a callback to call when the request is done
  * @data: (closure): data to pass to @callback
@@ -352,7 +352,7 @@ create_session (CreateCall *call)
 void
 xdp_portal_create_screencast_session (XdpPortal *portal,
                                       XdpOutputType outputs,
-                                      gboolean multiple,
+                                      XdpScreencastFlags flags,
                                       GCancellable *cancellable,
                                       GAsyncReadyCallback  callback,
                                       gpointer data)
@@ -360,13 +360,14 @@ xdp_portal_create_screencast_session (XdpPortal *portal,
   CreateCall *call;
 
   g_return_if_fail (XDP_IS_PORTAL (portal));
+  g_return_if_fail ((flags & ~(XDP_SCREENCAST_FLAG_MULTIPLE)) == 0);
 
   call = g_new0 (CreateCall, 1);
   call->portal = g_object_ref (portal);
   call->type = XDP_SESSION_SCREENCAST;
   call->devices = XDP_DEVICE_NONE;
   call->outputs = outputs;
-  call->multiple = multiple;
+  call->multiple = (flags & XDP_SCREENCAST_FLAG_MULTIPLE) != 0;
   call->task = g_task_new (portal, cancellable, callback, data);
 
   create_session (call);
@@ -404,7 +405,7 @@ xdp_portal_create_screencast_session_finish (XdpPortal *portal,
  * @portal: a #XdpPortal
  * @devices: which kinds of input devices to ofer in the new dialog
  * @outputs: which kinds of source to offer in the dialog
- * @multiple: whether to allow selecting multiple sources
+ * @flags: options for this call
  * @cancellable: (nullable): optional #GCancellable
  * @callback: (scope async): a callback to call when the request is done
  * @data: (closure): data to pass to @callback
@@ -418,7 +419,7 @@ void
 xdp_portal_create_remote_desktop_session (XdpPortal *portal,
                                           XdpDeviceType devices,
                                           XdpOutputType outputs,
-                                          gboolean multiple,
+                                          XdpRemoteDesktopFlags flags,
                                           GCancellable *cancellable,
                                           GAsyncReadyCallback  callback,
                                           gpointer data)
@@ -426,13 +427,14 @@ xdp_portal_create_remote_desktop_session (XdpPortal *portal,
   CreateCall *call;
 
   g_return_if_fail (XDP_IS_PORTAL (portal));
+  g_return_if_fail ((flags & ~(XDP_REMOTE_DESKTOP_FLAG_MULTIPLE)) == 0);
 
   call = g_new0 (CreateCall, 1);
   call->portal = g_object_ref (portal);
   call->type = XDP_SESSION_REMOTE_DESKTOP;
   call->devices = devices;
   call->outputs = outputs;
-  call->multiple = multiple;
+  call->multiple = (flags & XDP_REMOTE_DESKTOP_FLAG_MULTIPLE) != 0;
   call->task = g_task_new (portal, cancellable, callback, data);
 
   create_session (call);

--- a/libportal/remote.h
+++ b/libportal/remote.h
@@ -36,26 +36,13 @@ GType xdp_session_get_type (void) G_GNUC_CONST;
  * Flags to specify what kind of sources to offer for a screencast session.
  */
 typedef enum {
-  XDP_OUTPUT_MONITOR = 1,
-  XDP_OUTPUT_WINDOW  = 2
+  XDP_OUTPUT_MONITOR = 1 << 0,
+  XDP_OUTPUT_WINDOW  = 1 << 1
 } XdpOutputType;
 
 /**
- * XDP_OUTPUT_NONE:
- *
- * The value to use as null value for XdpOutputType.
- */
-#define XDP_OUTPUT_NONE 0
-
-/**
- * XDP_OUTPUT_ALL:
- *
- * A convenient value to select all possible kinds of output.
- */
-#define XDP_OUTPUT_ALL  (XDP_OUTPUT_MONITOR | XDP_OUTPUT_WINDOW)
-
-/**
  * XdpDeviceType:
+ * @XDP_DEVICE_NONE: no device
  * @XDP_DEVICE_KEYBOARD: control the keyboard.
  * @XDP_DEVICE_POINTER: control the pointer.
  * @XDP_DEVICE_TOUCHSCREEN: control the touchscreen.
@@ -63,24 +50,11 @@ typedef enum {
  * Flags to specify what input devices to control for a remote desktop session.
  */
 typedef enum {
-  XDP_DEVICE_KEYBOARD    = 1,
-  XDP_DEVICE_POINTER     = 2,
-  XDP_DEVICE_TOUCHSCREEN = 4
+  XDP_DEVICE_NONE        = 0,
+  XDP_DEVICE_KEYBOARD    = 1 << 0,
+  XDP_DEVICE_POINTER     = 1 << 1,
+  XDP_DEVICE_TOUCHSCREEN = 1 << 2
 } XdpDeviceType;
-
-/**
- * XDP_DEVICE_NONE:
- *
- * The value to use as null value for XdpDeviceType.
- */
-#define XDP_DEVICE_NONE 0
-
-/**
- * XDP_DEVICE_ALL:
- *
- * A convenient value to select all possible input devices.
- */
-#define XDP_DEVICE_ALL (XDP_DEVICE_KEYBOARD | XDP_DEVICE_POINTER | XDP_DEVICE_TOUCHSCREEN)
 
 /**
  * XdpSessionType:
@@ -108,10 +82,22 @@ typedef enum {
   XDP_SESSION_CLOSED
 } XdpSessionState;
 
+/**
+ * XdpScreencastFlags:
+ * @XDP_SCREENCAST_FLAG_NONE: No options
+ * @XDP_SCREENCAST_FLAG_MULTIPLE: allow opening multiple streams
+ *
+ * Options for starting screen casts.
+ */
+typedef enum {
+  XDP_SCREENCAST_FLAG_NONE     = 0,
+  XDP_SCREENCAST_FLAG_MULTIPLE = 1 << 0
+} XdpScreencastFlags;
+
 XDP_PUBLIC
 void        xdp_portal_create_screencast_session            (XdpPortal            *portal,
                                                              XdpOutputType         outputs,
-                                                             gboolean              multiple,
+                                                             XdpScreencastFlags    flags,
                                                              GCancellable         *cancellable,
                                                              GAsyncReadyCallback   callback,
                                                              gpointer              data);
@@ -121,19 +107,31 @@ XdpSession *xdp_portal_create_screencast_session_finish     (XdpPortal          
                                                              GAsyncResult         *result,
                                                              GError              **error);
 
-XDP_PUBLIC
-void        xdp_portal_create_remote_desktop_session        (XdpPortal            *portal,
-                                                             XdpDeviceType         devices,
-                                                             XdpOutputType         outputs,
-                                                             gboolean              multiple,
-                                                             GCancellable         *cancellable,
-                                                             GAsyncReadyCallback   callback,
-                                                             gpointer              data);
+/**
+ * XdpRemoteDesktopFlags:
+ * @XDP_REMOTE_DESKTOP_FLAG_NONE: No options
+ * @XDP_REMOTE_DESKTOP_FLAG_MULTIPLE: allow opening multiple streams
+ *
+ * Options for starting remote desktop sessions.
+ */
+typedef enum {
+  XDP_REMOTE_DESKTOP_FLAG_NONE     = 0,
+  XDP_REMOTE_DESKTOP_FLAG_MULTIPLE = 1 << 0
+} XdpRemoteDesktopFlags;
 
 XDP_PUBLIC
-XdpSession *xdp_portal_create_remote_desktop_session_finish (XdpPortal            *portal,
-                                                             GAsyncResult         *result,
-                                                             GError              **error);
+void        xdp_portal_create_remote_desktop_session        (XdpPortal              *portal,
+                                                             XdpDeviceType           devices,
+                                                             XdpOutputType           outputs,
+                                                             XdpRemoteDesktopFlags   flags,
+                                                             GCancellable           *cancellable,
+                                                             GAsyncReadyCallback     callback,
+                                                             gpointer                data);
+
+XDP_PUBLIC
+XdpSession *xdp_portal_create_remote_desktop_session_finish (XdpPortal              *portal,
+                                                             GAsyncResult           *result,
+                                                             GError                **error);
 
 XDP_PUBLIC
 void        xdp_session_start                (XdpSession           *session,

--- a/libportal/screenshot.h
+++ b/libportal/screenshot.h
@@ -21,11 +21,15 @@
 
 G_BEGIN_DECLS
 
+typedef enum {
+  XDP_SCREENSHOT_FLAG_NONE        = 0,
+  XDP_SCREENSHOT_FLAG_INTERACTIVE = 1 << 0
+} XdpScreenshotFlags;
+
 XDP_PUBLIC
 void       xdp_portal_take_screenshot        (XdpPortal           *portal,
                                               XdpParent           *parent,
-                                              gboolean             modal,
-                                              gboolean             interactive,
+                                              XdpScreenshotFlags   flags,
                                               GCancellable        *cancellable,
                                               GAsyncReadyCallback  callback,
                                               gpointer             data);

--- a/libportal/spawn.c
+++ b/libportal/spawn.c
@@ -237,6 +237,11 @@ xdp_portal_spawn (XdpPortal            *portal,
   SpawnCall *call;
 
   g_return_if_fail (XDP_IS_PORTAL (portal));
+  g_return_if_fail ((flags & !(XDP_SPAWN_FLAG_CLEARENV |
+                               XDP_SPAWN_FLAG_LATEST |
+                               XDP_SPAWN_FLAG_SANDBOX |
+                               XDP_SPAWN_FLAG_NO_NETWORK |
+                               XDP_SPAWN_FLAG_WATCH)) == 0);
 
   call = g_new (SpawnCall, 1);
   call->portal = g_object_ref (portal);

--- a/libportal/spawn.h
+++ b/libportal/spawn.h
@@ -23,6 +23,7 @@ G_BEGIN_DECLS
 
 /**
  * XdpSpawnFlags:
+ * @XDP_SPAWN_FLAG_NONE: No flags
  * @XDP_SPAWN_FLAG_CLEARENV: Clear the environment
  * @XDP_SPAWN_FLAG_LATEST: Spawn the latest version of the app
  * @XDP_SPAWN_FLAG_SANDBOX: Spawn in a sandbox (equivalent to the --sandbox option of flatpak run)
@@ -33,6 +34,7 @@ G_BEGIN_DECLS
  * new sandbox is created.
  */
 typedef enum {
+  XDP_SPAWN_FLAG_NONE       = 0,
   XDP_SPAWN_FLAG_CLEARENV   = 1 << 0,
   XDP_SPAWN_FLAG_LATEST     = 1 << 1,
   XDP_SPAWN_FLAG_SANDBOX    = 1 << 2,

--- a/libportal/updates.c
+++ b/libportal/updates.c
@@ -217,6 +217,7 @@ create_monitor (CreateMonitorCall *call)
 /**
  * xdp_portal_update_monitor_start:
  * @portal: a #XdpPortal
+ * @flags: options for this cal..
  * @cancellable: (nullable): optional #GCancellable
  * @callback: (scope async): a callback to call when the request is done
  * @data: (closure): data to pass to @callback
@@ -230,6 +231,7 @@ create_monitor (CreateMonitorCall *call)
  */
 void
 xdp_portal_update_monitor_start (XdpPortal *portal,
+                                 XdpUpdateMonitorFlags flags,
                                  GCancellable *cancellable,
                                  GAsyncReadyCallback callback,
                                  gpointer data)
@@ -237,6 +239,7 @@ xdp_portal_update_monitor_start (XdpPortal *portal,
   CreateMonitorCall *call;
 
   g_return_if_fail (XDP_IS_PORTAL (portal));
+  g_return_if_fail (flags == XDP_UPDATE_MONITOR_FLAG_NONE);
 
   call = g_new (CreateMonitorCall, 1);
   call->portal = g_object_ref (portal);
@@ -396,6 +399,7 @@ install_update (InstallUpdateCall *call)
  * xdp_portal_update_install:
  * @portal: a #XdpPortal
  * @parent: a #XdpParent
+ * @flags: options for this call
  * @cancellable: (nullable): optional #GCancellable
  * @callback: (scope async): a callback to call when the request is done
  * @data: (closure): data to pass to @callback
@@ -409,6 +413,7 @@ install_update (InstallUpdateCall *call)
 void
 xdp_portal_update_install (XdpPortal *portal,
                            XdpParent *parent,
+                           XdpUpdateInstallFlags flags,
                            GCancellable *cancellable,
                            GAsyncReadyCallback callback,
                            gpointer data)
@@ -416,6 +421,7 @@ xdp_portal_update_install (XdpPortal *portal,
   InstallUpdateCall *call;
 
   g_return_if_fail (XDP_IS_PORTAL (portal));
+  g_return_if_fail (flags == XDP_UPDATE_INSTALL_FLAG_NONE);
 
   call = g_new (InstallUpdateCall, 1);
   call->portal = g_object_ref (portal);

--- a/libportal/updates.h
+++ b/libportal/updates.h
@@ -39,30 +39,42 @@ typedef enum {
   XDP_UPDATE_STATUS_FAILED
 } XdpUpdateStatus;
 
-XDP_PUBLIC
-void       xdp_portal_update_monitor_start        (XdpPortal            *portal,
-                                                   GCancellable         *cancellable,
-                                                   GAsyncReadyCallback   callback,
-                                                   gpointer              data);
+typedef enum
+{
+  XDP_UPDATE_MONITOR_FLAG_NONE = 0,
+} XdpUpdateMonitorFlags;
 
 XDP_PUBLIC
-gboolean   xdp_portal_update_monitor_start_finish (XdpPortal            *portal,
-                                                   GAsyncResult         *result,
-                                                   GError              **error);
+void       xdp_portal_update_monitor_start        (XdpPortal              *portal,
+                                                   XdpUpdateMonitorFlags   flags,
+                                                   GCancellable           *cancellable,
+                                                   GAsyncReadyCallback     callback,
+                                                   gpointer                data);
 
 XDP_PUBLIC
-void       xdp_portal_update_monitor_stop         (XdpPortal            *portal);
+gboolean   xdp_portal_update_monitor_start_finish (XdpPortal              *portal,
+                                                   GAsyncResult           *result,
+                                                   GError                **error);
 
 XDP_PUBLIC
-void       xdp_portal_update_install              (XdpPortal            *portal,
-                                                   XdpParent            *parent,
-                                                   GCancellable         *cancellable,
-                                                   GAsyncReadyCallback   callback,
-                                                   gpointer              data);
+void       xdp_portal_update_monitor_stop         (XdpPortal              *portal);
+
+typedef enum
+{
+  XDP_UPDATE_INSTALL_FLAG_NONE = 0,
+} XdpUpdateInstallFlags;
 
 XDP_PUBLIC
-gboolean   xdp_portal_update_install_finish       (XdpPortal            *portal,
-                                                   GAsyncResult         *result,
-                                                   GError              **error);
+void       xdp_portal_update_install              (XdpPortal              *portal,
+                                                   XdpParent              *parent,
+                                                   XdpUpdateInstallFlags   flags,
+                                                   GCancellable           *cancellable,
+                                                   GAsyncReadyCallback     callback,
+                                                   gpointer                data);
+
+XDP_PUBLIC
+gboolean   xdp_portal_update_install_finish       (XdpPortal              *portal,
+                                                   GAsyncResult           *result,
+                                                   GError                **error);
 
 G_END_DECLS

--- a/libportal/wallpaper.h
+++ b/libportal/wallpaper.h
@@ -22,16 +22,20 @@
 G_BEGIN_DECLS
 
 /**
- * XdpWallpaperTarget:
- * @XDP_WALLPAPER_TARGET_BACKGROUND: Set wallpaper on the desktop background
- * @XDP_WALLPAPER_TARGET_LOCKSCREEN: Set wallpaper on the lockscreen
+ * XdpWallpaperFlags:
+ * @XDP_WALLPAPER_FLAG_NONE: No flags
+ * @XDP_WALLPAPER_FLAG_BACKGROUND: Set wallpaper on the desktop background
+ * @XDP_WALLPAPER_FLAG_LOCKSCREEN: Set wallpaper on the lockscreen
+ * @XDP_WALLPAPER_FLAG_PREVIEW: Request the preview to be shown
  *
  * The values of this enumeration determine where the wallpaper is being set.
  */
 typedef enum {
-  XDP_WALLPAPER_TARGET_BACKGROUND = 1 << 0,
-  XDP_WALLPAPER_TARGET_LOCKSCREEN = 1 << 1
-} XdpWallpaperTarget;
+  XDP_WALLPAPER_FLAG_NONE       = 0,  
+  XDP_WALLPAPER_FLAG_BACKGROUND = 1 << 0,
+  XDP_WALLPAPER_FLAG_LOCKSCREEN = 1 << 1,
+  XDP_WALLPAPER_FLAG_PREVIEW    = 1 << 2
+} XdpWallpaperFlags;
 
 #define XDP_WALLPAPER_TARGET_BOTH (XDP_WALLPAPER_TARGET_BACKGROUND|XDP_WALLPAPER_TARGET_LOCKSCREEN)
 
@@ -39,8 +43,7 @@ XDP_PUBLIC
 void       xdp_portal_set_wallpaper           (XdpPortal            *portal,
                                                XdpParent            *parent,
                                                const char           *uri,
-                                               gboolean              show_preview,
-                                               XdpWallpaperTarget    target,
+                                               XdpWallpaperFlags     flags,
                                                GCancellable         *cancellable,
                                                GAsyncReadyCallback   callback,
                                                gpointer              data);


### PR DESCRIPTION
Add flags to most calls that might grow new
options in the future, and turn boolean arguments
into flags where suitable.

Update portal-test to these changes.