### PR TITLE
Convert some debug printfs into g_debug()

### DIFF
--- a/libportal/background.c
+++ b/libportal/background.c
@@ -199,7 +199,7 @@ request_background (BackgroundCall *call)
   if (call->commandline)
     g_variant_builder_add (&options, "{sv}", "commandline", g_variant_new_strv ((const char* const*)call->commandline->pdata, call->commandline->len));
 
-g_print ("calling background\n");
+  g_debug ("calling background");
   g_dbus_connection_call (call->portal->bus,
                           PORTAL_BUS_NAME,
                           PORTAL_OBJECT_PATH,

--- a/libportal/updates.c
+++ b/libportal/updates.c
@@ -108,7 +108,7 @@ update_progress_received (GDBusConnection *bus,
       g_variant_lookup (info, "error", "&s", &error);
       g_variant_lookup (info, "error_message", "&s", &error_message);
     }
-g_print ("update progress received %u/%u %u%% %d\n", op, n_ops, progress, status);
+  g_debug ("update progress received %u/%u %u%% %d", op, n_ops, progress, status);
 
   g_signal_emit_by_name (portal, "update-progress",
                          n_ops,


### PR DESCRIPTION
g_print() is problematic for library users that have machine-readable
output like TAP or JSON on stdout, whereas the g_log() family are
easy to divert to stderr in such cases.