### PR TITLE
Use a GNOME background to test setting wallpaper

### DIFF
--- a/portal-test/portal-test-win.c
+++ b/portal-test/portal-test-win.c
@@ -1162,7 +1162,7 @@ set_wallpaper (PortalTestWin *win)
 {
   XdpParent *parent;
 //  const char *uri = "https://gitlab.gnome.org/GNOME/gtk/raw/master/demos/gtk-demo/portland-rose.jpg";
-  const char *uri = "file:////var/home/mclasen/portland-rose.jpg";
+  const char *uri = "file:///usr/share/backgrounds/gnome/adwaita-morning.jpg";
 
   parent = xdp_parent_new_gtk (GTK_WINDOW (win));
   xdp_portal_set_wallpaper (win->portal,


### PR DESCRIPTION
Other portal-test users don't have the maintainer's home directory,
so use a path that developers are somewhat likely to have.