### PR TITLE
XdpParent: rename export and unexport to avoid collision with keywords

### DIFF
--- a/libportal/account.c
+++ b/libportal/account.c
@@ -49,7 +49,7 @@ account_call_free (AccountCall *call)
   g_debug ("freeing AccountCall");
   if (call->parent)
     {
-      call->parent->unexport (call->parent);
+      call->parent->parent_unexport (call->parent);
       _xdp_parent_free (call->parent);
     }
   g_free (call->parent_handle);
@@ -162,7 +162,7 @@ get_user_information (AccountCall *call)
 
   if (call->parent_handle == NULL)
     {   
-      call->parent->export (call->parent, parent_exported, call);
+      call->parent->parent_export (call->parent, parent_exported, call);
       return;
     }
 

--- a/libportal/background.c
+++ b/libportal/background.c
@@ -53,7 +53,7 @@ background_call_free (BackgroundCall *call)
 {
   if (call->parent)
     {
-      call->parent->unexport (call->parent);
+      call->parent->parent_unexport (call->parent);
       _xdp_parent_free (call->parent);
     }
   g_free (call->parent_handle);
@@ -168,7 +168,7 @@ request_background (BackgroundCall *call)
 
   if (call->parent_handle == NULL)
     {
-      call->parent->export (call->parent, parent_exported, call);
+      call->parent->parent_export (call->parent, parent_exported, call);
       return;
     }
 

--- a/libportal/email.c
+++ b/libportal/email.c
@@ -67,7 +67,7 @@ email_call_free (EmailCall *call)
 {
   if (call->parent)
     {
-      call->parent->unexport (call->parent);
+      call->parent->parent_unexport (call->parent);
       _xdp_parent_free (call->parent);
     }
   g_free (call->parent_handle);
@@ -192,7 +192,7 @@ compose_email (EmailCall *call)
 
   if (call->parent_handle == NULL)
     {
-      call->parent->export (call->parent, parent_exported, call);
+      call->parent->parent_export (call->parent, parent_exported, call);
       return;
     }
 

--- a/libportal/filechooser.c
+++ b/libportal/filechooser.c
@@ -61,7 +61,7 @@ file_call_free (FileCall *call)
 {
   if (call->parent)
     {
-      call->parent->unexport (call->parent);
+      call->parent->parent_unexport (call->parent);
       _xdp_parent_free (call->parent);
     }
   g_free (call->parent_handle);
@@ -185,7 +185,7 @@ open_file (FileCall *call)
 
   if (call->parent_handle == NULL)
     {
-      call->parent->export (call->parent, parent_exported, call);
+      call->parent->parent_export (call->parent, parent_exported, call);
       return;
     }
 

--- a/libportal/inhibit.c
+++ b/libportal/inhibit.c
@@ -54,7 +54,7 @@ inhibit_call_free (InhibitCall *call)
 {
   if (call->parent)
     {
-      call->parent->unexport (call->parent);
+      call->parent->parent_unexport (call->parent);
       _xdp_parent_free (call->parent);
     }
  g_free (call->parent_handle);
@@ -168,7 +168,7 @@ do_inhibit (InhibitCall *call)
 
   if (call->parent_handle == NULL)
     {
-      call->parent->export (call->parent, inhibit_parent_exported, call);
+      call->parent->parent_export (call->parent, inhibit_parent_exported, call);
       return;
     }
 
@@ -346,7 +346,7 @@ create_monitor_call_free (CreateMonitorCall *call)
 {
   if (call->parent)
     {
-      call->parent->unexport (call->parent);
+      call->parent->parent_unexport (call->parent);
       _xdp_parent_free (call->parent);
     }
   g_free (call->parent_handle);
@@ -512,7 +512,7 @@ create_monitor (CreateMonitorCall *call)
 
   if (call->parent_handle == NULL)
     {
-      call->parent->export (call->parent, create_parent_exported, call);
+      call->parent->parent_export (call->parent, create_parent_exported, call);
       return;
     }
 

--- a/libportal/location.c
+++ b/libportal/location.c
@@ -50,7 +50,7 @@ create_call_free (CreateCall *call)
 {
   if (call->parent)
     {
-      call->parent->unexport (call->parent);
+      call->parent->parent_unexport (call->parent);
       _xdp_parent_free (call->parent);
     }
  g_free (call->parent_handle);
@@ -276,7 +276,7 @@ create_session (CreateCall *call)
 
   if (call->parent_handle == NULL)
     {
-      call->parent->export (call->parent, parent_exported, call);
+      call->parent->parent_export (call->parent, parent_exported, call);
       return;
     }
 

--- a/libportal/openuri.c
+++ b/libportal/openuri.c
@@ -61,7 +61,7 @@ open_call_free (OpenCall *call)
 {
   if (call->parent)
     {
-      call->parent->unexport (call->parent);
+      call->parent->parent_unexport (call->parent);
       _xdp_parent_free (call->parent);
     }
   g_free (call->parent_handle);
@@ -177,7 +177,7 @@ do_open (OpenCall *call)
 
   if (call->parent_handle == NULL)
     {
-      call->parent->export (call->parent, parent_exported, call);
+      call->parent->parent_export (call->parent, parent_exported, call);
       return;
     }
 

--- a/libportal/portal-gtk3.h
+++ b/libportal/portal-gtk3.h
@@ -91,8 +91,8 @@ static inline XdpParent *xdp_parent_new_gtk (GtkWindow *window);
 static inline XdpParent *xdp_parent_new_gtk (GtkWindow *window)
 {
   XdpParent *parent = g_new0 (XdpParent, 1);
-  parent->export = _xdp_parent_export_gtk;
-  parent->unexport = _xdp_parent_unexport_gtk;
+  parent->parent_export = _xdp_parent_export_gtk;
+  parent->parent_unexport = _xdp_parent_unexport_gtk;
   parent->object = (GObject *) g_object_ref (window);
   return parent;
 }

--- a/libportal/portal-gtk4.h
+++ b/libportal/portal-gtk4.h
@@ -91,8 +91,8 @@ static inline XdpParent *xdp_parent_new_gtk (GtkWindow *window);
 static inline XdpParent *xdp_parent_new_gtk (GtkWindow *window)
 {
   XdpParent *parent = g_new0 (XdpParent, 1);
-  parent->export = _xdp_parent_export_gtk;
-  parent->unexport = _xdp_parent_unexport_gtk;
+  parent->parent_export = _xdp_parent_export_gtk;
+  parent->parent_unexport = _xdp_parent_unexport_gtk;
   parent->object = (GObject *) g_object_ref (window);
   return parent;
 }

--- a/libportal/portal-helpers.h
+++ b/libportal/portal-helpers.h
@@ -54,8 +54,8 @@ typedef void     (* XdpParentUnexport) (XdpParent         *parent);
 
 struct _XdpParent {
   /*< private >*/
-  XdpParentExport export;
-  XdpParentUnexport unexport;
+  XdpParentExport parent_export;
+  XdpParentUnexport parent_unexport;
   GObject *object;
   XdpParentExported callback;
   gpointer data;

--- a/libportal/print.c
+++ b/libportal/print.c
@@ -65,7 +65,7 @@ print_call_free (PrintCall *call)
 {
   if (call->parent)
     {
-      call->parent->unexport (call->parent);
+      call->parent->parent_unexport (call->parent);
       _xdp_parent_free (call->parent);
     }
   g_free (call->parent_handle);
@@ -190,7 +190,7 @@ do_print (PrintCall *call)
 
   if (call->parent_handle == NULL)
     {
-      call->parent->export (call->parent, parent_exported, call);
+      call->parent->parent_export (call->parent, parent_exported, call);
       return;
     }
 

--- a/libportal/remote.c
+++ b/libportal/remote.c
@@ -485,7 +485,7 @@ start_call_free (StartCall *call)
 {
   if (call->parent)
     {
-      call->parent->unexport (call->parent);
+      call->parent->parent_unexport (call->parent);
       _xdp_parent_free (call->parent);
     }
   g_free (call->parent_handle);
@@ -582,7 +582,7 @@ start_session (StartCall *call)
 
   if (call->parent_handle == NULL)
     {
-      call->parent->export (call->parent, parent_exported, call);
+      call->parent->parent_export (call->parent, parent_exported, call);
       return;
     }
 

--- a/libportal/screenshot.c
+++ b/libportal/screenshot.c
@@ -48,7 +48,7 @@ screenshot_call_free (ScreenshotCall *call)
 {
   if (call->parent)
     {
-      call->parent->unexport (call->parent);
+      call->parent->parent_unexport (call->parent);
       _xdp_parent_free (call->parent);
     }
   g_free (call->parent_handle);
@@ -177,7 +177,7 @@ take_screenshot (ScreenshotCall *call)
 
   if (call->parent_handle == NULL)
     {
-      call->parent->export (call->parent, parent_exported, call);
+      call->parent->parent_export (call->parent, parent_exported, call);
       return;
     }
 

--- a/libportal/updates.c
+++ b/libportal/updates.c
@@ -317,7 +317,7 @@ install_update_call_free (InstallUpdateCall *call)
 {
   if (call->parent)
     {
-      call->parent->unexport (call->parent);
+      call->parent->parent_unexport (call->parent);
       _xdp_parent_free (call->parent);
     }
   g_free (call->parent_handle);
@@ -373,7 +373,7 @@ install_update (InstallUpdateCall *call)
 
   if (call->parent_handle == NULL)
     {
-      call->parent->export (call->parent, create_parent_exported, call);
+      call->parent->parent_export (call->parent, create_parent_exported, call);
       return;
     }
 

--- a/libportal/utils.c
+++ b/libportal/utils.c
@@ -26,8 +26,8 @@ _xdp_parent_copy (XdpParent *source)
 
   parent = g_new0 (XdpParent, 1);
 
-  parent->export = source->export;
-  parent->unexport = source->unexport;
+  parent->parent_export = source->parent_export;
+  parent->parent_unexport = source->parent_unexport;
   g_set_object (&parent->object, source->object);
 
   return parent;

--- a/libportal/wallpaper.c
+++ b/libportal/wallpaper.c
@@ -59,7 +59,7 @@ wallpaper_call_free (WallpaperCall *call)
 {
   if (call->parent)
     {
-      call->parent->unexport (call->parent);
+      call->parent->parent_unexport (call->parent);
       _xdp_parent_free (call->parent);
     }
   g_free (call->parent_handle);
@@ -192,7 +192,7 @@ set_wallpaper (WallpaperCall *call)
 
   if (call->parent_handle == NULL)
     {
-      call->parent->export (call->parent, parent_exported, call);
+      call->parent->parent_export (call->parent, parent_exported, call);
       return;
     }
 


### PR DESCRIPTION
In C++, name "export" is a keyword and using libportal in a C++ applications fails to build because of that.