### PR TITLE
OpenURI: open file with write access when requested

### DIFF
--- a/libportal/openuri.c
+++ b/libportal/openuri.c
@@ -209,11 +209,16 @@ do_open (OpenCall *call)
     {
       g_autoptr(GUnixFDList) fd_list = NULL;
       g_autofree char *path = NULL;
-      int fd, fd_in;
+      int fd, fd_in, flags;
 
       path = g_file_get_path (file);
 
-      fd = g_open (path, O_PATH | O_CLOEXEC);
+      if (call->writable)
+        flags = O_RDWR | O_CLOEXEC;
+      else
+        flags = O_RDONLY | O_CLOEXEC;
+
+      fd = g_open (path, flags);
       if (fd == -1)
         {
           g_task_return_new_error (call->task, G_IO_ERROR, G_IO_ERROR_FAILED, "Failed to open '%s'", call->uri);


### PR DESCRIPTION
When user specifies to open a file with write access, we need to open it with specified permission, otherwise xdg-desktop-portal will fail as it checks for write access.

Also follow glib and do not use O_PATH, because since xdg-desktop-portal 1.0.1, regular file descriptors are also accepted.

For reference:
1) [Glib change](https://gitlab.gnome.org/GNOME/glib/-/commit/e244a78fbcbba3ab116f5a62f724a8f6cd926570)
2) [Portal bug](https://github.com/flatpak/xdg-desktop-portal/issues/167)