### PR TITLE
camera: Support selecting a camera

### DIFF
--- a/libportal/camera.h
+++ b/libportal/camera.h
@@ -42,6 +42,11 @@ gboolean xdp_portal_access_camera_finish (XdpPortal           *portal,
                                           GError             **error);
 
 XDP_PUBLIC
+GVariant * xdp_portal_access_camera_finish_streams (XdpPortal     *portal,
+                                                    GAsyncResult  *result,
+                                                    GError       **error);
+
+XDP_PUBLIC
 int      xdp_portal_open_pipewire_remote_for_camera (XdpPortal *portal);
 
 G_END_DECLS


### PR DESCRIPTION
Add a variant of xdp_portal_access_camera_finish called
xdp_portal_access_camera_finish_streams that returns
information about what camera was selected, in the same
format that screencast sessions return stream information.