### PR TITLE
CI: Add mono apt repository

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo add-apt-repository ppa:alexlarsson/glib260
+        sudo add-apt-repository 'deb https://download.mono-project.com/repo/ubuntu stable-bionic main' # Needed for updates to work
         sudo apt-get update
         sudo apt-get install -y libglib2.0 gettext dbus gtk-doc-tools meson
     - name: Check out libportal


### PR DESCRIPTION
Copy-pasting [1]. This fixes the pre-build step.

[1] https://github.com/flatpak/flatpak-builder/commit/1898b36d1fae6f011e5465982154e18320549470