### PR TITLE
[API Break] Add cursor mode to remote APIs

### DIFF
--- a/libportal/meson.build
+++ b/libportal/meson.build
@@ -57,8 +57,7 @@ install_headers(headers, subdir: 'libportal')
 
 libportal = library('portal',
                     src,
-                    version: '0.0.1',
-                    soversion: 0,
+                    version: '1.0.0',
                     include_directories: [top_inc, libportal_inc],
                     c_args: visibility_args,
                     install: true,

--- a/libportal/remote.c
+++ b/libportal/remote.c
@@ -53,6 +53,7 @@ typedef struct {
   XdpSessionType type;
   XdpDeviceType devices;
   XdpOutputType outputs;
+  XdpCursorMode cursor_mode;
   gboolean multiple;
   guint signal_id;
   GTask *task;
@@ -150,6 +151,7 @@ select_sources (CreateCall *call)
   g_variant_builder_add (&options, "{sv}", "handle_token", g_variant_new_string (token));
   g_variant_builder_add (&options, "{sv}", "types", g_variant_new_uint32 (call->outputs));
   g_variant_builder_add (&options, "{sv}", "multiple", g_variant_new_boolean (call->multiple));
+  g_variant_builder_add (&options, "{sv}", "cursor_mode", g_variant_new_uint32 (call->cursor_mode));
   g_dbus_connection_call (call->portal->bus,
                           PORTAL_BUS_NAME,
                           PORTAL_OBJECT_PATH,
@@ -342,6 +344,7 @@ create_session (CreateCall *call)
  * @portal: a #XdpPortal
  * @outputs: which kinds of source to offer in the dialog
  * @flags: options for this call
+ * @cursor_mode: the cursor mode of the session
  * @cancellable: (nullable): optional #GCancellable
  * @callback: (scope async): a callback to call when the request is done
  * @data: (closure): data to pass to @callback
@@ -355,6 +358,7 @@ void
 xdp_portal_create_screencast_session (XdpPortal *portal,
                                       XdpOutputType outputs,
                                       XdpScreencastFlags flags,
+                                      XdpCursorMode cursor_mode,
                                       GCancellable *cancellable,
                                       GAsyncReadyCallback  callback,
                                       gpointer data)
@@ -369,6 +373,7 @@ xdp_portal_create_screencast_session (XdpPortal *portal,
   call->type = XDP_SESSION_SCREENCAST;
   call->devices = XDP_DEVICE_NONE;
   call->outputs = outputs;
+  call->cursor_mode = cursor_mode;
   call->multiple = (flags & XDP_SCREENCAST_FLAG_MULTIPLE) != 0;
   call->task = g_task_new (portal, cancellable, callback, data);
 
@@ -408,6 +413,7 @@ xdp_portal_create_screencast_session_finish (XdpPortal *portal,
  * @devices: which kinds of input devices to ofer in the new dialog
  * @outputs: which kinds of source to offer in the dialog
  * @flags: options for this call
+ * @cursor_mode: the cursor mode of the session
  * @cancellable: (nullable): optional #GCancellable
  * @callback: (scope async): a callback to call when the request is done
  * @data: (closure): data to pass to @callback
@@ -422,6 +428,7 @@ xdp_portal_create_remote_desktop_session (XdpPortal *portal,
                                           XdpDeviceType devices,
                                           XdpOutputType outputs,
                                           XdpRemoteDesktopFlags flags,
+                                          XdpCursorMode cursor_mode,
                                           GCancellable *cancellable,
                                           GAsyncReadyCallback  callback,
                                           gpointer data)
@@ -436,6 +443,7 @@ xdp_portal_create_remote_desktop_session (XdpPortal *portal,
   call->type = XDP_SESSION_REMOTE_DESKTOP;
   call->devices = devices;
   call->outputs = outputs;
+  call->cursor_mode = cursor_mode;
   call->multiple = (flags & XDP_REMOTE_DESKTOP_FLAG_MULTIPLE) != 0;
   call->task = g_task_new (portal, cancellable, callback, data);
 

--- a/libportal/remote.h
+++ b/libportal/remote.h
@@ -96,10 +96,25 @@ typedef enum {
   XDP_SCREENCAST_FLAG_MULTIPLE = 1 << 0
 } XdpScreencastFlags;
 
+/**
+ * XdpCursorMode:
+ * @XDP_CURSOR_MODE_HIDDEN: no cursor
+ * @XDP_CURSOR_MODE_EMBEDDED: cursor is embedded on the stream
+ * @XDP_CURSOR_MODE_METADATA: cursor is sent as metadata of the stream
+ *
+ * Options for how the cursor is handled.
+ */
+typedef enum {
+  XDP_CURSOR_MODE_HIDDEN   = 1 << 0,
+  XDP_CURSOR_MODE_EMBEDDED = 1 << 1,
+  XDP_CURSOR_MODE_METADATA = 1 << 2,
+} XdpCursorMode;
+
 XDP_PUBLIC
 void        xdp_portal_create_screencast_session            (XdpPortal            *portal,
                                                              XdpOutputType         outputs,
                                                              XdpScreencastFlags    flags,
+                                                             XdpCursorMode         cursor_mode,
                                                              GCancellable         *cancellable,
                                                              GAsyncReadyCallback   callback,
                                                              gpointer              data);
@@ -126,6 +141,7 @@ void        xdp_portal_create_remote_desktop_session        (XdpPortal          
                                                              XdpDeviceType           devices,
                                                              XdpOutputType           outputs,
                                                              XdpRemoteDesktopFlags   flags,
+                                                             XdpCursorMode           cursor_mode,
                                                              GCancellable           *cancellable,
                                                              GAsyncReadyCallback     callback,
                                                              gpointer                data);

--- a/portal-test/gtk3/portal-test-win.c
+++ b/portal-test/gtk3/portal-test-win.c
@@ -617,7 +617,13 @@ start_screencast (PortalTestWin *win)
 {
   g_clear_object (&win->session);
 
-  xdp_portal_create_screencast_session (win->portal, XDP_OUTPUT_MONITOR|XDP_OUTPUT_WINDOW, XDP_SCREENCAST_FLAG_NONE, NULL, session_created, win);
+  xdp_portal_create_screencast_session (win->portal,
+                                        XDP_OUTPUT_MONITOR | XDP_OUTPUT_WINDOW,
+                                        XDP_SCREENCAST_FLAG_NONE,
+                                        XDP_CURSOR_MODE_HIDDEN,
+                                        NULL,
+                                        session_created,
+                                        win);
 }
 
 static void

--- a/portal-test/gtk4/portal-test-win.c
+++ b/portal-test/gtk4/portal-test-win.c
@@ -574,7 +574,13 @@ start_screencast (PortalTestWin *win)
 {
   g_clear_object (&win->session);
 
-  xdp_portal_create_screencast_session (win->portal, XDP_OUTPUT_MONITOR|XDP_OUTPUT_WINDOW, XDP_SCREENCAST_FLAG_NONE, NULL, session_created, win);
+  xdp_portal_create_screencast_session (win->portal,
+                                        XDP_OUTPUT_MONITOR | XDP_OUTPUT_WINDOW,
+                                        XDP_SCREENCAST_FLAG_NONE,
+                                        XDP_CURSOR_MODE_HIDDEN,
+                                        NULL,
+                                        session_created,
+                                        win);
 }
 
 static void


### PR DESCRIPTION
There currently is no way to pass a cursor mode when creating
a screencast / remote desktop session, which is pretty limiting.

Add XdpCursorMode, and the corresponding parameters to the session
functions.