### PR TITLE
portal-helpers: Unref correct object

### DIFF
--- a/libportal/portal-helpers.h
+++ b/libportal/portal-helpers.h
@@ -67,7 +67,7 @@ static inline void xdp_parent_free (XdpParent *parent);
 
 static inline void xdp_parent_free (XdpParent *parent)
 {
-  g_clear_object (&parent->data);
+  g_clear_object (&parent->object);
   g_free (parent);
 }
 


### PR DESCRIPTION
xdp_parent_free() was calling g_object_unref() at the
'data' field of _XdpParent, but the actual GObject field
is 'object'.

Unref the correct field, 'object', instead of the 'data'
field.