### PR TITLE
Add libportal-qt

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,13 @@ jobs:
         sudo add-apt-repository ppa:alexlarsson/glib260
         sudo add-apt-repository 'deb https://download.mono-project.com/repo/ubuntu stable-bionic main' # Needed for updates to work
         sudo apt-get update
-        sudo apt-get install -y libglib2.0 gettext dbus gtk-doc-tools meson
+        sudo apt-get install -y libglib2.0 gettext dbus gtk-doc-tools meson qt5-default libqt5gui5 cmake qtbase5-dev qtbase5-private-dev
     - name: Check out libportal
       uses: actions/checkout@v1
     - name: Configure libportal
-      run: meson setup --prefix=/usr _build -Dbackends=
+      run: meson setup --prefix=/usr _build -Dbackends=qt5 -Dtests=true
     - name: Build libportal
       run: ninja -C_build
+    - name: Run tests
+      run: meson test -C_build
+

--- a/libportal-qt/account.cpp
+++ b/libportal-qt/account.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2020-2021, Jan Grulich
+ *
+ * This file is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, version 3.0 of the
+ * License.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-only
+ */
+
+#include "account.h"
+#include "parent.h"
+#include "parent_p.h"
+#include "portal_p.h"
+
+namespace Xdp
+{
+
+void Xdp::PortalPrivate::getUserInformation(const Parent &parent, const QString &reason, UserInformationFlags flags)
+{
+    xdp_portal_get_user_information(m_xdpPortal, parent.d_ptr->m_xdpParent, reason.toUtf8().constData(), static_cast<XdpUserInformationFlags>((int)flags), nullptr, gotUserInformation, this);
+}
+
+void Xdp::PortalPrivate::gotUserInformation(GObject *object, GAsyncResult *result, gpointer data)
+{
+    XdpPortal *xdpPortal = XDP_PORTAL(object);
+    PortalPrivate *portalPrivate = static_cast<PortalPrivate*>(data);
+    g_autoptr(GError) error = nullptr;
+    g_autofree gchar *id = nullptr;
+    g_autofree gchar *name = nullptr;
+    g_autofree gchar *image = nullptr;
+
+    g_autoptr(GVariant) ret = xdp_portal_get_user_information_finish(xdpPortal, result, &error);
+
+    if (ret) {
+        QVariantMap responseData;
+        if (g_variant_lookup(ret, "id", "s", &id)) {
+            responseData.insert(QStringLiteral("id"), id);
+        }
+
+        if (g_variant_lookup(ret, "name", "s", &name)) {
+            responseData.insert(QStringLiteral("name"), name);
+        }
+
+        if (g_variant_lookup(ret, "image", "s", &image)) {
+            responseData.insert(QStringLiteral("image"), image);
+        }
+
+        Response response(true, error, responseData);
+        Q_EMIT portalPrivate->getUserInformationResponse(response);
+    } else {
+        Response response(false, error);
+        Q_EMIT portalPrivate->getUserInformationResponse(response);
+    }
+}
+
+}

--- a/libportal-qt/account.h
+++ b/libportal-qt/account.h
@@ -17,32 +17,21 @@
  * SPDX-License-Identifier: LGPL-3.0-only
  */
 
-#ifndef PORTAL_TEST_QT_H
-#define PORTAL_TEST_QT_H
+#ifndef LIBPORTALQT_ACCOUNT_H
+#define LIBPORTALQT_ACCOUNT_H
 
-#include <QMainWindow>
-#include "portal.h"
+#include <QFlags>
 
-class Ui_PortalTestQt;
-
-class PortalTestQt : public QMainWindow
+namespace Xdp
 {
-    Q_OBJECT
-public:
-    PortalTestQt(QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
-    ~PortalTestQt();
 
-    void updateLastOpenedFile(const QString &file);
-private Q_SLOTS:
-    void onUserInformationReceived(const Xdp::Response &response);
-    void onFileOpened(const Xdp::Response &response);
-    void onSessionInhibited(const Xdp::Response &response);
-
-private:
-    Ui_PortalTestQt *m_mainWindow;
-    int m_inhibitorId = -1;
-    QString m_fileToPrint;
-    int m_printToken;
+enum class UserInformationFlag
+{
+    None = 0x0
 };
+Q_DECLARE_FLAGS(UserInformationFlags, UserInformationFlag)
+}
+Q_DECLARE_OPERATORS_FOR_FLAGS(Xdp::UserInformationFlags)
 
-#endif // PORTAL_TEST_QT_H
+#endif // LIBPORTALQT_ACCOUNT_H
+

--- a/libportal-qt/background.cpp
+++ b/libportal-qt/background.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2020-2021, Jan Grulich
+ *
+ * This file is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, version 3.0 of the
+ * License.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-only
+ */
+
+#include "background.h"
+#include "parent.h"
+#include "parent_p.h"
+#include "portal_p.h"
+
+namespace Xdp
+{
+
+void PortalPrivate::requestBackground(const Parent &parent, const QString &reason, const QStringList &commandline, BackgroundFlags flags)
+{
+    g_autoptr(GPtrArray) ptrArray = g_ptr_array_new();
+
+    for (const QString &cmdPart : commandline) {
+        g_ptr_array_add(ptrArray, static_cast<gpointer>(g_strdup(cmdPart.toUtf8().constData())));
+    }
+
+    xdp_portal_request_background(m_xdpPortal, parent.d_ptr->m_xdpParent, const_cast<char*>(reason.toUtf8().constData()), ptrArray, static_cast<XdpBackgroundFlags>((int)flags), nullptr, requestedBackground, this);
+}
+
+void PortalPrivate::requestedBackground(GObject *object, GAsyncResult *result, gpointer data)
+{
+    XdpPortal *xdpPortal = XDP_PORTAL(object);
+    PortalPrivate *portalPrivate = static_cast<PortalPrivate*>(data);
+    g_autoptr(GError) error = nullptr;
+
+    bool ret = xdp_portal_request_background_finish(xdpPortal, result, &error);
+
+    Response response(ret, error);
+
+    portalPrivate->requestBackgroundResponse(response);
+}
+
+}

--- a/libportal-qt/background.h
+++ b/libportal-qt/background.h
@@ -17,32 +17,23 @@
  * SPDX-License-Identifier: LGPL-3.0-only
  */
 
-#ifndef PORTAL_TEST_QT_H
-#define PORTAL_TEST_QT_H
+#ifndef LIBPORTALQT_BACKGROUND_H
+#define LIBPORTALQT_BACKGROUND_H
 
-#include <QMainWindow>
-#include "portal.h"
+#include <QFlags>
 
-class Ui_PortalTestQt;
-
-class PortalTestQt : public QMainWindow
+namespace Xdp
 {
-    Q_OBJECT
-public:
-    PortalTestQt(QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
-    ~PortalTestQt();
 
-    void updateLastOpenedFile(const QString &file);
-private Q_SLOTS:
-    void onUserInformationReceived(const Xdp::Response &response);
-    void onFileOpened(const Xdp::Response &response);
-    void onSessionInhibited(const Xdp::Response &response);
-
-private:
-    Ui_PortalTestQt *m_mainWindow;
-    int m_inhibitorId = -1;
-    QString m_fileToPrint;
-    int m_printToken;
+enum class BackgroundFlag
+{
+    None = 0x0,
+    Autostart = 0x1,
+    Activatable = 0x2
 };
+Q_DECLARE_FLAGS(BackgroundFlags, BackgroundFlag)
+}
+Q_DECLARE_OPERATORS_FOR_FLAGS(Xdp::BackgroundFlags)
 
-#endif // PORTAL_TEST_QT_H
+#endif // LIBPORTALQT_BACKGROUND_H
+

--- a/libportal-qt/camera.cpp
+++ b/libportal-qt/camera.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2020-2021, Jan Grulich
+ *
+ * This file is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, version 3.0 of the
+ * License.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-only
+ */
+
+#include "camera.h"
+#include "parent.h"
+#include "parent_p.h"
+#include "portal_p.h"
+
+namespace Xdp
+{
+
+void PortalPrivate::accessCamera(const Parent &parent, CameraFlags flags)
+{
+    xdp_portal_access_camera(m_xdpPortal, parent.d_ptr->m_xdpParent, static_cast<XdpCameraFlags>((int)flags), nullptr, accessedCamera, this);
+}
+
+void PortalPrivate::accessedCamera(GObject *object, GAsyncResult *result, gpointer data)
+{
+    XdpPortal *xdpPortal = XDP_PORTAL(object);
+    PortalPrivate *portalPrivate = static_cast<PortalPrivate*>(data);
+    g_autoptr(GError) error = nullptr;
+
+    bool ret = xdp_portal_access_camera_finish(xdpPortal, result, &error);
+
+    Response response(ret, error);
+    portalPrivate->accessCameraResponse(response);
+}
+
+int PortalPrivate::openPipewireRemoteForCamera()
+{
+    return xdp_portal_open_pipewire_remote_for_camera(m_xdpPortal);
+}
+
+}

--- a/libportal-qt/camera.h
+++ b/libportal-qt/camera.h
@@ -17,32 +17,22 @@
  * SPDX-License-Identifier: LGPL-3.0-only
  */
 
-#ifndef PORTAL_TEST_QT_H
-#define PORTAL_TEST_QT_H
+#ifndef LIBPORTALQT_CAMERA_H
+#define LIBPORTALQT_CAMERA_H
 
-#include <QMainWindow>
-#include "portal.h"
+#include <QFlags>
 
-class Ui_PortalTestQt;
-
-class PortalTestQt : public QMainWindow
+namespace Xdp
 {
-    Q_OBJECT
-public:
-    PortalTestQt(QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
-    ~PortalTestQt();
 
-    void updateLastOpenedFile(const QString &file);
-private Q_SLOTS:
-    void onUserInformationReceived(const Xdp::Response &response);
-    void onFileOpened(const Xdp::Response &response);
-    void onSessionInhibited(const Xdp::Response &response);
-
-private:
-    Ui_PortalTestQt *m_mainWindow;
-    int m_inhibitorId = -1;
-    QString m_fileToPrint;
-    int m_printToken;
+enum class CameraFlag
+{
+    None = 0x0
 };
+Q_DECLARE_FLAGS(CameraFlags, CameraFlag)
+}
+Q_DECLARE_OPERATORS_FOR_FLAGS(Xdp::CameraFlags)
 
-#endif // PORTAL_TEST_QT_H
+#endif // LIBPORTALQT_CAMERA_H
+
+

--- a/libportal-qt/cmake/LibPortalQtConfig.cmake.in
+++ b/libportal-qt/cmake/LibPortalQtConfig.cmake.in
@@ -1,0 +1,41 @@
+
+get_filename_component(PACKAGE_PREFIX_DIR "${CMAKE_CURRENT_LIST_DIR}/../../../../" ABSOLUTE)
+
+# Use original install prefix when loaded through a "/usr move"
+# cross-prefix symbolic link such as /lib -> /usr/lib.
+get_filename_component(_realCurr "${CMAKE_CURRENT_LIST_DIR}" REALPATH)
+get_filename_component(_realOrig "@LIBDIR_FULL@/cmake/LibPortalQt" REALPATH)
+if(_realCurr STREQUAL _realOrig)
+  set(PACKAGE_PREFIX_DIR "@PREFIX@")
+endif()
+unset(_realOrig)
+unset(_realCurr)
+
+macro(set_and_check _var _file)
+  set(${_var} "${_file}")
+  if(NOT EXISTS "${_file}")
+    message(FATAL_ERROR "File or directory ${_file} referenced by variable ${_var} does not exist !")
+  endif()
+endmacro()
+
+macro(check_required_components _NAME)
+  foreach(comp ${${_NAME}_FIND_COMPONENTS})
+    if(NOT ${_NAME}_${comp}_FOUND)
+      if(${_NAME}_FIND_REQUIRED_${comp})
+        set(${_NAME}_FOUND FALSE)
+      endif()
+    endif()
+  endforeach()
+endmacro()
+
+add_library(LibPortalQt SHARED IMPORTED)
+set_target_properties(LibPortalQt PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES "${PACKAGE_PREFIX_DIR}/include/"
+  INTERFACE_LINK_LIBRARIES "Qt5::Core"
+  IMPORTED_LOCATION "@LIBDIR_FULL@/libLibPortalQt.so.${LibPortalQt_VERSION}"
+  IMPORTED_SONAME "libLibPortalQt.${LibPortalQt_VERSION_MAJOR}"
+)
+
+####################################################################################
+
+check_required_components(Qt5Core)

--- a/libportal-qt/cmake/LibPortalQtConfigVersion.cmake.in
+++ b/libportal-qt/cmake/LibPortalQtConfigVersion.cmake.in
@@ -1,0 +1,32 @@
+# This is a basic version file for the Config-mode of find_package().
+# It is used by write_basic_package_version_file() as input file for configure_file()
+# to create a version-file which can be installed along a config.cmake file.
+#
+# The created file sets PACKAGE_VERSION_EXACT if the current version string and
+# the requested version string are exactly the same and it sets
+# PACKAGE_VERSION_COMPATIBLE if the current version is >= requested version,
+# but only if the requested major version is the same as the current one.
+# The variable CVF_VERSION must be set before calling configure_file().
+
+set(PACKAGE_VERSION "@VERSION@")
+
+if(PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION)
+  set(PACKAGE_VERSION_COMPATIBLE FALSE)
+else()
+
+  if("@VERSION@" MATCHES "^([0-9]+)\\.")
+    set(CVF_VERSION_MAJOR "${CMAKE_MATCH_1}")
+  else()
+    set(CVF_VERSION_MAJOR "@VERSION@")
+  endif()
+
+  if(PACKAGE_FIND_VERSION_MAJOR STREQUAL CVF_VERSION_MAJOR)
+    set(PACKAGE_VERSION_COMPATIBLE TRUE)
+  else()
+    set(PACKAGE_VERSION_COMPATIBLE FALSE)
+  endif()
+
+  if(PACKAGE_FIND_VERSION STREQUAL PACKAGE_VERSION)
+      set(PACKAGE_VERSION_EXACT TRUE)
+  endif()
+endif()

--- a/libportal-qt/email.cpp
+++ b/libportal-qt/email.cpp
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2020-2021, Jan Grulich
+ *
+ * This file is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, version 3.0 of the
+ * License.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-only
+ */
+
+#include "email.h"
+#include "parent.h"
+#include "parent_p.h"
+#include "portal_p.h"
+
+#include <string.h>
+#include <iostream>
+
+namespace Xdp
+{
+
+void PortalPrivate::composeEmail(const Parent &parent, const QStringList &addresses, const QStringList &cc,
+                                 const QStringList &bcc, const QString &subject, const QString &body,
+                                 const QStringList &attachments, EmailFlags flags)
+{
+    int i = 0;
+    char *addressesArray[addresses.size() + 1];
+    char *ccArray[cc.size() + 1];
+    char *bccArray[bcc.size() + 1];
+    char *attachmentsArray[attachments.size() + 1];
+
+    while (i < addresses.size()) {
+        addressesArray[i] = new char[addresses.at(i).length() + 1];
+        strcpy(addressesArray[i], addresses.at(i).toLatin1());
+        addressesArray[i][addresses.at(i).length()] = '\0';
+        i++;
+    }
+    addressesArray[i] = nullptr;
+
+    i = 0;
+    while (i < cc.size()) {
+        ccArray[i] = new char[cc.at(i).length() + 1];
+        strcpy(ccArray[i], cc.at(i).toLatin1());
+        ccArray[i][cc.at(i).length()] = '\0';
+        i++;
+    }
+    ccArray[i] = nullptr;
+
+    i = 0;
+    while (i < bcc.size()) {
+        bccArray[i] = new char[bcc.at(i).length() + 1];
+        strcpy(bccArray[i], bcc.at(i).toLatin1());
+        bccArray[i][bcc.at(i).length()] = '\0';
+        i++;
+    }
+    bccArray[i] = nullptr;
+
+    i = 0;
+    while (i < attachments.size()) {
+        attachmentsArray[i] = new char[attachments.at(i).length() + 1];
+        strcpy(attachmentsArray[i], attachments.at(i).toLatin1());
+        attachmentsArray[i][attachments.at(i).length()] = '\0';
+        i++;
+    }
+    attachmentsArray[i] = nullptr;
+
+    xdp_portal_compose_email(m_xdpPortal, parent.d_ptr->m_xdpParent, addressesArray, ccArray, bccArray, const_cast<char*>(subject.toUtf8().constData()),
+                             const_cast<char*>(body.toUtf8().constData()), attachmentsArray, static_cast<XdpEmailFlags>((int)flags), nullptr, composedEmail, this);
+
+    i = 0;
+    while (i < addresses.size()) {
+        delete addressesArray[i];
+        i++;
+    }
+
+    i = 0;
+    while (i < cc.size()) {
+        delete ccArray[i];
+        i++;
+    }
+
+    i = 0;
+    while (i < bcc.size()) {
+        delete bccArray[i];
+        i++;
+    }
+
+    i = 0;
+    while (i < attachments.size()) {
+        delete attachmentsArray[i];
+        i++;
+    }
+}
+
+void PortalPrivate::composedEmail(GObject *object, GAsyncResult *result, gpointer data)
+{
+    XdpPortal *xdpPortal = XDP_PORTAL(object);
+    PortalPrivate *portalPrivate = static_cast<PortalPrivate*>(data);
+    g_autoptr(GError) error = nullptr;
+
+    bool ret = xdp_portal_compose_email_finish(xdpPortal, result, &error);
+
+    Response response(ret, error);
+    portalPrivate->composeEmailResponse(response);
+}
+
+}

--- a/libportal-qt/email.h
+++ b/libportal-qt/email.h
@@ -17,32 +17,23 @@
  * SPDX-License-Identifier: LGPL-3.0-only
  */
 
-#ifndef PORTAL_TEST_QT_H
-#define PORTAL_TEST_QT_H
+#ifndef LIBPORTALQT_EMAIL_H
+#define LIBPORTALQT_EMAIL_H
 
-#include <QMainWindow>
-#include "portal.h"
+#include <QFlags>
 
-class Ui_PortalTestQt;
-
-class PortalTestQt : public QMainWindow
+namespace Xdp
 {
-    Q_OBJECT
-public:
-    PortalTestQt(QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
-    ~PortalTestQt();
 
-    void updateLastOpenedFile(const QString &file);
-private Q_SLOTS:
-    void onUserInformationReceived(const Xdp::Response &response);
-    void onFileOpened(const Xdp::Response &response);
-    void onSessionInhibited(const Xdp::Response &response);
-
-private:
-    Ui_PortalTestQt *m_mainWindow;
-    int m_inhibitorId = -1;
-    QString m_fileToPrint;
-    int m_printToken;
+enum class EmailFlag
+{
+    None = 0x0
 };
+Q_DECLARE_FLAGS(EmailFlags, EmailFlag)
+}
+Q_DECLARE_OPERATORS_FOR_FLAGS(Xdp::EmailFlags)
 
-#endif // PORTAL_TEST_QT_H
+#endif // LIBPORTALQT_EMAIL_H
+
+
+

--- a/libportal-qt/filechooser.cpp
+++ b/libportal-qt/filechooser.cpp
@@ -1,0 +1,536 @@
+/*
+ * Copyright (C) 2020-2021, Jan Grulich
+ *
+ * This file is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, version 3.0 of the
+ * License.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-only
+ */
+
+#include "filechooser.h"
+#include "portal.h"
+#include "parent.h"
+#include "parent_p.h"
+#include "portal_p.h"
+
+#include <QFile>
+
+namespace Xdp
+{
+
+class FileChooserFilterRulePrivate
+{
+public:
+    FileChooserFilterRulePrivate();
+    FileChooserFilterRulePrivate(FileChooserFilterRule::Type type, const QString &rule);
+    FileChooserFilterRulePrivate(const FileChooserFilterRulePrivate &other);
+    ~FileChooserFilterRulePrivate() { };
+
+    FileChooserFilterRule::Type m_type = FileChooserFilterRule::Type::Pattern;
+    QString m_rule;
+};
+
+FileChooserFilterRulePrivate::FileChooserFilterRulePrivate()
+{
+}
+
+FileChooserFilterRulePrivate::FileChooserFilterRulePrivate(FileChooserFilterRule::Type type, const QString &rule)
+    : m_type(type)
+    , m_rule(rule)
+{
+}
+
+FileChooserFilterRulePrivate::FileChooserFilterRulePrivate(const FileChooserFilterRulePrivate &other)
+    : FileChooserFilterRulePrivate(other.m_type, other.m_rule)
+{
+}
+
+FileChooserFilterRule::FileChooserFilterRule()
+    : d_ptr(new FileChooserFilterRulePrivate())
+{
+}
+
+FileChooserFilterRule::FileChooserFilterRule(FileChooserFilterRule::Type type, const QString &rule)
+    : d_ptr(new FileChooserFilterRulePrivate(type, rule))
+{
+}
+
+
+FileChooserFilterRule::FileChooserFilterRule(const FileChooserFilterRule &other)
+    : FileChooserFilterRule(other.type(), other.rule())
+{
+}
+
+FileChooserFilterRule::~FileChooserFilterRule()
+{
+}
+
+void FileChooserFilterRule::operator=(const FileChooserFilterRule &other)
+{
+    setRule(other.rule());
+    setType(other.type());
+}
+
+bool FileChooserFilterRule::isValid() const
+{
+    Q_D(const FileChooserFilterRule);
+    return !d->m_rule.isEmpty();
+}
+
+FileChooserFilterRule::Type FileChooserFilterRule::type() const
+{
+    Q_D(const FileChooserFilterRule);
+    return d->m_type;
+}
+
+void FileChooserFilterRule::setType(FileChooserFilterRule::Type type)
+{
+    Q_D(FileChooserFilterRule);
+    d->m_type = type;
+}
+
+QString FileChooserFilterRule::rule() const
+{
+    Q_D(const FileChooserFilterRule);
+    return d->m_rule;
+}
+
+void FileChooserFilterRule::setRule(const QString &rule)
+{
+    Q_D(FileChooserFilterRule);
+    d->m_rule = rule;
+}
+
+class FileChooserFilterPrivate
+{
+public:
+    FileChooserFilterPrivate() { };
+    FileChooserFilterPrivate(const QString &label, const FileChooserFilterRules &rules);
+    FileChooserFilterPrivate(const FileChooserFilterPrivate &other);
+    ~FileChooserFilterPrivate() { };
+
+    QString m_label;
+    FileChooserFilterRules m_rules;
+};
+
+FileChooserFilterPrivate::FileChooserFilterPrivate(const QString &label, const FileChooserFilterRules &rules)
+    : m_label(label)
+    , m_rules(rules)
+{
+}
+
+FileChooserFilterPrivate::FileChooserFilterPrivate(const FileChooserFilterPrivate &other)
+    : FileChooserFilterPrivate(other.m_label, other.m_rules)
+{
+}
+
+FileChooserFilter::FileChooserFilter()
+    : d_ptr(new FileChooserFilterPrivate())
+{
+}
+
+FileChooserFilter::FileChooserFilter(const QString &label, const FileChooserFilterRules &rules)
+    : d_ptr(new FileChooserFilterPrivate(label, rules))
+{
+}
+
+FileChooserFilter::FileChooserFilter(const FileChooserFilter &other)
+    : FileChooserFilter(other.label(), other.rules())
+{
+}
+
+FileChooserFilter::~FileChooserFilter()
+{
+}
+
+void FileChooserFilter::operator=(const FileChooserFilter &other)
+{
+    setLabel(other.label());
+    for (const FileChooserFilterRule &rule : other.rules()) {
+        addRule(rule);
+    }
+}
+
+bool FileChooserFilter::isValid() const
+{
+    Q_D(const FileChooserFilter);
+    if (d->m_label.isEmpty() || d->m_rules.isEmpty()) {
+        return false;
+    }
+
+    for (const FileChooserFilterRule &rule : d->m_rules) {
+        if (!rule.isValid()) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+QString FileChooserFilter::label() const
+{
+    Q_D(const FileChooserFilter);
+    return d->m_label;
+}
+
+void FileChooserFilter::setLabel(const QString &label)
+{
+    Q_D(FileChooserFilter);
+    d->m_label = label;
+}
+
+FileChooserFilterRules FileChooserFilter::rules() const
+{
+    Q_D(const FileChooserFilter);
+    return d->m_rules;
+}
+
+void FileChooserFilter::addRule(const FileChooserFilterRule &rule)
+{
+    Q_D(FileChooserFilter);
+    d->m_rules << rule;
+}
+
+class FileChooserChoicePrivate
+{
+public:
+    FileChooserChoicePrivate();
+    FileChooserChoicePrivate(const QString &id, const QString &label, const QMap<QString, QString> &options, const QString &selected);
+    FileChooserChoicePrivate(const FileChooserChoicePrivate &other);
+    ~FileChooserChoicePrivate() { };
+
+    QString m_id;
+    QString m_label;
+    QMap<QString, QString> m_options;
+    QString m_selected;
+};
+
+FileChooserChoicePrivate::FileChooserChoicePrivate()
+{
+}
+
+FileChooserChoicePrivate::FileChooserChoicePrivate(const QString &id, const QString &label, const QMap<QString, QString> &options, const QString &selected)
+    : m_id(id)
+    , m_label(label)
+    , m_options(options)
+    , m_selected(selected)
+{
+}
+
+FileChooserChoicePrivate::FileChooserChoicePrivate(const FileChooserChoicePrivate &other)
+    : FileChooserChoicePrivate(other.m_id, other.m_label, other.m_options, other.m_selected)
+{
+}
+
+FileChooserChoice::FileChooserChoice()
+    : d_ptr(new FileChooserChoicePrivate())
+{
+}
+
+FileChooserChoice::FileChooserChoice(const QString &id, const QString &label, const QMap<QString, QString> &choices, const QString &selected)
+    : d_ptr(new FileChooserChoicePrivate(id, label, choices, selected))
+{
+}
+
+FileChooserChoice::FileChooserChoice(const FileChooserChoice &other)
+    : FileChooserChoice(other.id(), other.label(), other.options(), other.selected())
+{
+}
+
+FileChooserChoice::~FileChooserChoice()
+{
+}
+
+void FileChooserChoice::operator=(const FileChooserChoice &other)
+{
+    setId(other.id());
+    setLabel(other.label());
+    setSelected(other.selected());
+
+    QMap<QString, QString>::iterator it = other.options().begin();
+    while (it != other.options().end()) {
+        addOption(it.value(), it.key());
+    }
+}
+
+bool FileChooserChoice::isValid() const
+{
+    Q_D(const FileChooserChoice);
+    return !d->m_id.isEmpty() && !d->m_label.isEmpty() && !d->m_options.isEmpty();
+}
+
+QString FileChooserChoice::id() const
+{
+    Q_D(const FileChooserChoice);
+    return d->m_id;
+}
+
+void FileChooserChoice::setId(const QString &id)
+{
+    Q_D(FileChooserChoice);
+    d->m_id = id;
+}
+
+QString FileChooserChoice::label() const
+{
+    Q_D(const FileChooserChoice);
+    return d->m_label;
+}
+
+void FileChooserChoice::setLabel(const QString &label)
+{
+    Q_D(FileChooserChoice);
+    d->m_label = label;
+}
+
+QMap<QString, QString> FileChooserChoice::options() const
+{
+    Q_D(const FileChooserChoice);
+    return d->m_options;
+}
+
+void FileChooserChoice::addOption(const QString &id, const QString &label)
+{
+    Q_D(FileChooserChoice);
+    d->m_options.insert(id, label);
+}
+
+QString FileChooserChoice::selected() const
+{
+    Q_D(const FileChooserChoice);
+    return d->m_selected;
+}
+
+void FileChooserChoice::setSelected(const QString& selected)
+{
+    Q_D(FileChooserChoice);
+    d->m_selected = selected;
+}
+
+GVariant *PortalPrivate::filterToVariant(const FileChooserFilter &filter)
+{
+    GVariantBuilder builder;
+
+    g_variant_builder_init(&builder, G_VARIANT_TYPE("a(us)"));
+
+    for (const FileChooserFilterRule &rule : filter.rules()) {
+        g_variant_builder_add(&builder, "(us)", static_cast<uint>(rule.type()), rule.rule().toUtf8().constData());
+    }
+
+    return g_variant_new("(s@a(us))", filter.label().toUtf8().constData(), g_variant_builder_end(&builder));
+}
+
+GVariant *PortalPrivate::filterListToVariant(const FileChooserFilterList &filters)
+{
+    GVariantBuilder builder;
+
+    g_variant_builder_init(&builder, G_VARIANT_TYPE("a(sa(us))"));
+
+    for (const FileChooserFilter &filter : filters) {
+        g_variant_builder_add(&builder, "@(sa(us))", filterToVariant(filter));
+    }
+
+    return g_variant_builder_end(&builder);
+}
+
+GVariant *PortalPrivate::choiceToVariant(const FileChooserChoice &choice)
+{
+    GVariantBuilder builder;
+
+    g_variant_builder_init(&builder, G_VARIANT_TYPE("a(ss)"));
+
+    if (choice.options().count()) {
+        for (auto it = choice.options().constBegin(); it != choice.options().constEnd(); ++it) {
+            g_variant_builder_add(&builder, "(&s&s)", it.key().toUtf8().constData(), it.value().toUtf8().constData());
+        }
+    }
+
+    return g_variant_new("(&s&s@a(ss)&s)", choice.id().toUtf8().constData(), choice.label().toUtf8().constData(),
+                         g_variant_builder_end(&builder), choice.selected().toUtf8().constData());
+}
+
+GVariant *PortalPrivate::choicesToVariant(const FileChooserChoices &choices)
+{
+    GVariantBuilder builder;
+
+    g_variant_builder_init(&builder, G_VARIANT_TYPE("a(ssa(ss)s)"));
+
+    for (const FileChooserChoice &choice : choices) {
+        g_variant_builder_add(&builder, "@(ssa(ss)s)",choiceToVariant(choice));
+    }
+
+    return g_variant_builder_end(&builder);
+}
+
+GVariant *PortalPrivate::filesToVariant(const QStringList &files)
+{
+    GVariantBuilder builder;
+
+    g_variant_builder_init(&builder, G_VARIANT_TYPE_BYTESTRING_ARRAY);
+
+    for (const QString &file : files) {
+        g_variant_builder_add(&builder, "@ay", g_variant_new_bytestring(file.toUtf8().constData()));
+    }
+
+    return g_variant_builder_end(&builder);
+}
+
+void PortalPrivate::openFile(const Parent &parent, const QString &title, const FileChooserFilterList &filters, const FileChooserFilter &currentFilter,
+                             const FileChooserChoices &choices, OpenFileFlags flags)
+{
+    xdp_portal_open_file(m_xdpPortal, parent.d_ptr->m_xdpParent, title.toUtf8().constData(), filterListToVariant(filters), currentFilter.isValid() ? filterToVariant(currentFilter) : nullptr,
+                         choicesToVariant(choices), static_cast<XdpOpenFileFlags>((int)flags), nullptr /*cancellable*/, openedFile, this);
+}
+
+void PortalPrivate::saveFile(const Parent &parent, const QString &title, const QString &currentName, const QString &currentFolder, const QString &currentFile,
+                             const FileChooserFilterList &filters, const FileChooserFilter &currentFilter, const FileChooserChoices &choices, SaveFileFlags flags)
+{
+    xdp_portal_save_file(m_xdpPortal, parent.d_ptr->m_xdpParent, title.toUtf8().constData(),  currentName.toUtf8().constData(),
+                         QFile::encodeName(currentFolder).append('\0'), QFile::encodeName(currentFile).append('\0'),
+                         filterListToVariant(filters), currentFilter.isValid() ? filterToVariant(currentFilter) : nullptr,
+                         choicesToVariant(choices), static_cast<XdpSaveFileFlags>((int)flags), nullptr /*cancellable*/, savedFile, this);
+}
+
+void PortalPrivate::saveFiles(const Parent &parent, const QString &title, const QString &currentFolder, const QStringList &files,
+                              const FileChooserChoices &choices, SaveFileFlags flags)
+{
+    xdp_portal_save_files(m_xdpPortal, parent.d_ptr->m_xdpParent, title.toUtf8().constData(), nullptr /*current_name*/,
+                          QFile::encodeName(currentFolder).append('\0'), filesToVariant(files),
+                          choicesToVariant(choices), static_cast<XdpSaveFileFlags>((int)flags), nullptr /*cancellable*/, savedFiles, this);
+}
+
+void PortalPrivate::openedFile(GObject *object, GAsyncResult *result, gpointer data)
+{
+    XdpPortal *xdpPortal = XDP_PORTAL(object);
+    PortalPrivate *portalPrivate = static_cast<PortalPrivate*>(data);
+
+    g_autofree const char **uris = nullptr;
+    g_autoptr(GError) error = nullptr;
+    GVariant *choices = nullptr;
+
+    g_autoptr(GVariant) ret = xdp_portal_open_file_finish(xdpPortal, result, &error);
+
+    if (ret) {
+        QVariantMap responseData;
+        g_variant_lookup(ret, "uris", "^a&s", &uris);
+
+        choices = g_variant_lookup_value(ret, "choices", G_VARIANT_TYPE("a(ss)"));
+        if (choices) {
+            QMap<QString, QString> choicesMap;
+            for (uint i = 0; i < g_variant_n_children(choices); i++) {
+                const char *id;
+                const char *selected;
+                g_variant_get_child(choices, i, "(&s&s)", &id, &selected);
+                choicesMap.insert(QString(id), QString(selected));
+            }
+            responseData.insert(QStringLiteral("choices"), QVariant::fromValue<QMap<QString, QString> >(choicesMap));
+            g_variant_unref (choices);
+        }
+
+        QStringList uriList;
+        for (int i = 0; uris[i]; i++) {
+            uriList << QString(uris[i]);
+        }
+        responseData.insert(QStringLiteral("uris"), uriList);
+
+        Response response(true, error, responseData);
+        portalPrivate->openFileResponse(response);
+    } else {
+        Response response(false, error);
+        portalPrivate->openFileResponse(response);
+    }
+}
+
+void PortalPrivate::savedFile(GObject *object, GAsyncResult *result, gpointer data)
+{
+    XdpPortal *xdpPortal = XDP_PORTAL(object);
+    PortalPrivate *portalPrivate = static_cast<PortalPrivate*>(data);
+
+    g_autofree const char **uris = nullptr;
+    g_autoptr(GError) error = nullptr;
+    g_autoptr(GVariant) choices = nullptr;
+    g_autoptr(GVariant) ret = xdp_portal_save_file_finish(xdpPortal, result, &error);
+
+    if (ret) {
+        QVariantMap responseData;
+        g_variant_lookup(ret, "uris", "^a&s", &uris);
+
+        choices = g_variant_lookup_value(ret, "choices", G_VARIANT_TYPE("a(ss)"));
+        if (choices) {
+            QMap<QString, QString> choicesMap;
+            for (uint i = 0; i < g_variant_n_children(choices); i++) {
+                const char *id;
+                const char *selected;
+                g_variant_get_child(choices, i, "(&s&s)", &id, &selected);
+                choicesMap.insert(QString(id), QString(selected));
+            }
+            responseData.insert(QStringLiteral("choices"), QVariant::fromValue<QMap<QString, QString> >(choicesMap));
+            g_variant_unref (choices);
+        }
+
+        QStringList uriList;
+        for (int i = 0; uris[i]; i++) {
+            uriList << QString(uris[i]);
+        }
+        responseData.insert(QStringLiteral("uris"), uriList);
+
+        Response response(true, error, responseData);
+        portalPrivate->saveFileResponse(response);
+    } else {
+        Response response(false, error);
+        portalPrivate->saveFileResponse(response);
+    }
+}
+
+void PortalPrivate::savedFiles(GObject *object, GAsyncResult *result, gpointer data)
+{
+    XdpPortal *xdpPortal = XDP_PORTAL(object);
+    PortalPrivate *portalPrivate = static_cast<PortalPrivate*>(data);
+
+    g_autofree const char **uris = nullptr;
+    g_autoptr(GError) error = nullptr;
+    g_autoptr(GVariant) choices = nullptr;
+    g_autoptr(GVariant) ret = xdp_portal_save_files_finish(xdpPortal, result, &error);
+
+    if (ret) {
+        QVariantMap responseData;
+        g_variant_lookup(ret, "uris", "^a&s", &uris);
+
+        choices = g_variant_lookup_value(ret, "choices", G_VARIANT_TYPE("a(ss)"));
+        if (choices) {
+            QMap<QString, QString> choicesMap;
+            for (uint i = 0; i < g_variant_n_children(choices); i++) {
+                const char *id;
+                const char *selected;
+                g_variant_get_child(choices, i, "(&s&s)", &id, &selected);
+                choicesMap.insert(QString(id), QString(selected));
+            }
+            responseData.insert(QStringLiteral("choices"), QVariant::fromValue<QMap<QString, QString> >(choicesMap));
+            g_variant_unref (choices);
+        }
+
+        QStringList uriList;
+        for (int i = 0; uris[i]; i++) {
+            uriList << QString(uris[i]);
+        }
+        responseData.insert(QStringLiteral("uris"), uriList);
+
+        Response response(true, error, responseData);
+        portalPrivate->saveFilesResponse(response);
+    } else {
+        Response response(false, error);
+        portalPrivate->saveFilesResponse(response);
+    }
+}
+
+}

--- a/libportal-qt/filechooser.h
+++ b/libportal-qt/filechooser.h
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2020-2021, Jan Grulich
+ *
+ * This file is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, version 3.0 of the
+ * License.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-only
+ */
+
+#ifndef LIBPORTALQT_FILECHOOSER_H
+#define LIBPORTALQT_FILECHOOSER_H
+
+#include "libportalqt_export.h"
+
+#include <QFlags>
+#include <QMap>
+#include <QStringList>
+#include <QSharedPointer>
+
+namespace Xdp
+{
+
+enum class OpenFileFlag
+{
+    None = 0x0,
+    Multiple = 0x1
+};
+Q_DECLARE_FLAGS(OpenFileFlags, OpenFileFlag)
+
+enum class SaveFileFlag
+{
+    None = 0x0
+};
+Q_DECLARE_FLAGS(SaveFileFlags, SaveFileFlag)
+
+class FileChooserFilterRulePrivate;
+
+class LIBPORTALQT_EXPORT FileChooserFilterRule
+{
+public:
+    enum class Type {
+        Pattern = 0,
+        Mimetype = 1
+    };
+
+    explicit FileChooserFilterRule();
+    FileChooserFilterRule(Type type, const QString &rule);
+    FileChooserFilterRule(const FileChooserFilterRule &other);
+    ~FileChooserFilterRule();
+
+    void operator=(const FileChooserFilterRule &other);
+
+    bool isValid() const;
+
+    Type type() const;
+    void setType(Type type);
+
+    QString rule() const;
+    void setRule(const QString &rule);
+private:
+    Q_DECLARE_PRIVATE(FileChooserFilterRule)
+
+    const QScopedPointer<FileChooserFilterRulePrivate> d_ptr;
+};
+typedef QList<FileChooserFilterRule> FileChooserFilterRules;
+
+class FileChooserFilterPrivate;
+
+class LIBPORTALQT_EXPORT FileChooserFilter
+{
+public:
+    explicit FileChooserFilter();
+    FileChooserFilter(const QString &label, const FileChooserFilterRules &rules);
+    FileChooserFilter(const FileChooserFilter &other);
+    ~FileChooserFilter();
+
+    void operator=(const FileChooserFilter &other);
+
+    bool isValid() const;
+
+    QString label() const;
+    void setLabel(const QString &label);
+
+    FileChooserFilterRules rules() const;
+    void addRule(const FileChooserFilterRule &rule);
+private:
+    Q_DECLARE_PRIVATE(FileChooserFilter)
+
+    const QScopedPointer<FileChooserFilterPrivate> d_ptr;
+};
+typedef QList<FileChooserFilter> FileChooserFilterList;
+
+class FileChooserChoicePrivate;
+
+class LIBPORTALQT_EXPORT FileChooserChoice
+{
+public:
+    explicit FileChooserChoice();
+    FileChooserChoice(const QString &id, const QString &label, const QMap<QString, QString> &options, const QString &selected = QString());
+    FileChooserChoice(const FileChooserChoice &other);
+    ~FileChooserChoice();
+
+    void operator=(const FileChooserChoice &other);
+
+    bool isValid() const;
+
+    QString id() const;
+    void setId(const QString &id);
+
+    QString label() const;
+    void setLabel(const QString &label);
+
+    QMap<QString, QString> options() const;
+    void addOption(const QString &id, const QString &label);
+
+    QString selected() const;
+    void setSelected(const QString &selected);
+
+private:
+    Q_DECLARE_PRIVATE(FileChooserChoice)
+
+    const QScopedPointer<FileChooserChoicePrivate> d_ptr;
+};
+typedef QList<FileChooserChoice> FileChooserChoices;
+
+}
+Q_DECLARE_OPERATORS_FOR_FLAGS(Xdp::OpenFileFlags)
+Q_DECLARE_OPERATORS_FOR_FLAGS(Xdp::SaveFileFlags)
+
+#endif // LIBPORTALQT_FILECHOOSER_H

--- a/libportal-qt/inhibit.cpp
+++ b/libportal-qt/inhibit.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2020-2021, Jan Grulich
+ *
+ * This file is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, version 3.0 of the
+ * License.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-only
+ */
+
+#include "inhibit.h"
+#include "portal.h"
+#include "parent.h"
+#include "parent_p.h"
+#include "portal_p.h"
+
+namespace Xdp
+{
+
+void PortalPrivate::sessionInhibit(const Parent &parent, const QString &reason, InhibitFlags flags)
+{
+    xdp_portal_session_inhibit(m_xdpPortal, parent.d_ptr->m_xdpParent, reason.toUtf8().constData(),
+                               static_cast<XdpInhibitFlags>((int)flags), nullptr /*cancellable*/, sessionInhibited, this);
+}
+
+void PortalPrivate::sessionInhibited(GObject *object, GAsyncResult *result, gpointer data)
+{
+    XdpPortal *xdpPortal = XDP_PORTAL(object);
+    PortalPrivate *portalPrivate = static_cast<PortalPrivate*>(data);
+    g_autoptr(GError) error = nullptr;
+
+    int ret = xdp_portal_session_inhibit_finish(xdpPortal, result, &error);
+
+    QVariantMap responseData;
+    responseData.insert(QStringLiteral("id"), ret);
+    Response response(ret, error, responseData);
+
+    portalPrivate->sessionInhibitResponse(response);
+}
+
+void PortalPrivate::sessionUninhibit(int id)
+{
+    xdp_portal_session_uninhibit(m_xdpPortal, id);
+}
+
+void PortalPrivate::sessionMonitorStart(const Parent &parent, SessionMonitorFlags flags)
+{
+    xdp_portal_session_monitor_start(m_xdpPortal, parent.d_ptr->m_xdpParent, static_cast<XdpSessionMonitorFlags>((int)flags),
+                                     nullptr /*cancellable*/, sessionMonitorStarted, this);
+}
+
+void PortalPrivate::sessionMonitorStarted(GObject *object, GAsyncResult *result, gpointer data)
+{
+    XdpPortal *xdpPortal = XDP_PORTAL(object);
+    PortalPrivate *portalPrivate = static_cast<PortalPrivate*>(data);
+    g_autoptr(GError) error = nullptr;
+
+    bool ret = xdp_portal_session_monitor_start_finish(xdpPortal, result, &error);
+
+    Response response(ret, error);
+
+    portalPrivate->sessionMonitorStartResponse(response);
+}
+
+void PortalPrivate::sessionMonitorStop()
+{
+    xdp_portal_session_monitor_stop(m_xdpPortal);
+}
+
+void PortalPrivate::sessionMonitorQueryEndResponse()
+{
+    xdp_portal_session_monitor_query_end_response(m_xdpPortal);
+}
+
+void PortalPrivate::onSessionStateChanged(XdpPortal *portal, gboolean screenSaverActive, XdpLoginSessionState currentState, gpointer data)
+{
+    Q_UNUSED(portal)
+
+    PortalPrivate *portalPrivate = static_cast<PortalPrivate*>(data);
+
+    portalPrivate->sessionStateChanged(screenSaverActive, static_cast<LoginSessionState>(currentState));
+}
+
+}

--- a/libportal-qt/inhibit.h
+++ b/libportal-qt/inhibit.h
@@ -17,32 +17,43 @@
  * SPDX-License-Identifier: LGPL-3.0-only
  */
 
-#ifndef PORTAL_TEST_QT_H
-#define PORTAL_TEST_QT_H
+#ifndef LIBPORTALQT_INHIBIT_H
+#define LIBPORTALQT_INHIBIT_H
 
-#include <QMainWindow>
-#include "portal.h"
+#include <QFlags>
 
-class Ui_PortalTestQt;
-
-class PortalTestQt : public QMainWindow
+namespace Xdp
 {
-    Q_OBJECT
-public:
-    PortalTestQt(QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
-    ~PortalTestQt();
 
-    void updateLastOpenedFile(const QString &file);
-private Q_SLOTS:
-    void onUserInformationReceived(const Xdp::Response &response);
-    void onFileOpened(const Xdp::Response &response);
-    void onSessionInhibited(const Xdp::Response &response);
+enum class InhibitFlag
+{
+    None = 0x0,
+    Logout = 0x1,
+    UserSwitch = 0x2,
+    Suspend = 0x4,
+    Idle = 0x8
+};
+Q_DECLARE_FLAGS(InhibitFlags, InhibitFlag)
 
-private:
-    Ui_PortalTestQt *m_mainWindow;
-    int m_inhibitorId = -1;
-    QString m_fileToPrint;
-    int m_printToken;
+enum class LoginSessionState
+{
+    Running = 1,
+    QueryEnd = 2,
+    Ending = 3
 };
 
-#endif // PORTAL_TEST_QT_H
+enum class SessionMonitorFlag
+{
+    None = 0x0
+};
+Q_DECLARE_FLAGS(SessionMonitorFlags, SessionMonitorFlag)
+
+}
+Q_DECLARE_OPERATORS_FOR_FLAGS(Xdp::InhibitFlags)
+Q_DECLARE_OPERATORS_FOR_FLAGS(Xdp::SessionMonitorFlags)
+
+#endif // LIBPORTALQT_INHIBIT_H
+
+
+
+

--- a/libportal-qt/libportalqt_export.h
+++ b/libportal-qt/libportalqt_export.h
@@ -1,0 +1,42 @@
+
+#ifndef LIBPORTALQT_EXPORT_H
+#define LIBPORTALQT_EXPORT_H
+
+#ifdef LIBPORTALQT_STATIC_DEFINE
+#  define LIBPORTALQT_EXPORT
+#  define LIBPORTALQT_NO_EXPORT
+#else
+#  ifndef LIBPORTALQT_EXPORT
+#    ifdef LibPortalQt_EXPORTS
+        /* We are building this library */
+#      define LIBPORTALQT_EXPORT __attribute__((visibility("default")))
+#    else
+        /* We are using this library */
+#      define LIBPORTALQT_EXPORT __attribute__((visibility("default")))
+#    endif
+#  endif
+
+#  ifndef LIBPORTALQT_NO_EXPORT
+#    define LIBPORTALQT_NO_EXPORT __attribute__((visibility("hidden")))
+#  endif
+#endif
+
+#ifndef LIBPORTALQT_DEPRECATED
+#  define LIBPORTALQT_DEPRECATED __attribute__ ((__deprecated__))
+#endif
+
+#ifndef LIBPORTALQT_DEPRECATED_EXPORT
+#  define LIBPORTALQT_DEPRECATED_EXPORT LIBPORTALQT_EXPORT LIBPORTALQT_DEPRECATED
+#endif
+
+#ifndef LIBPORTALQT_DEPRECATED_NO_EXPORT
+#  define LIBPORTALQT_DEPRECATED_NO_EXPORT LIBPORTALQT_NO_EXPORT LIBPORTALQT_DEPRECATED
+#endif
+
+#if 0 /* DEFINE_NO_DEPRECATED */
+#  ifndef LIBPORTALQT_NO_DEPRECATED
+#    define LIBPORTALQT_NO_DEPRECATED
+#  endif
+#endif
+
+#endif

--- a/libportal-qt/location.cpp
+++ b/libportal-qt/location.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2020-2021, Jan Grulich
+ *
+ * This file is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, version 3.0 of the
+ * License.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-only
+ */
+
+#include "location.h"
+#include "portal.h"
+#include "parent.h"
+#include "parent_p.h"
+#include "portal_p.h"
+
+namespace Xdp
+{
+
+void PortalPrivate::locationMonitorStart(const Parent &parent, uint distanceThreshold, uint timeThreshold, LocationAccuracy accuracy, LocationMonitorFlags flags)
+{
+    xdp_portal_location_monitor_start(m_xdpPortal, parent.d_ptr->m_xdpParent, distanceThreshold, timeThreshold, static_cast<XdpLocationAccuracy>(accuracy),
+                                      static_cast<XdpLocationMonitorFlags>((int)flags), nullptr /* cancellable */, locationMonitorStarted, this);
+}
+
+void PortalPrivate::locationMonitorStarted(GObject *object, GAsyncResult *result, gpointer data)
+{
+    XdpPortal *xdpPortal = XDP_PORTAL(object);
+    PortalPrivate *portalPrivate = static_cast<PortalPrivate*>(data);
+    g_autoptr(GError) error = nullptr;
+
+    bool ret = xdp_portal_location_monitor_start_finish(xdpPortal, result, &error);
+
+    Response response(ret, error);
+
+    portalPrivate->locationMonitorStartResponse(response);
+}
+
+void PortalPrivate::locationMonitorStop()
+{
+    xdp_portal_location_monitor_stop(m_xdpPortal);
+}
+
+void PortalPrivate::onLocationUpdated(XdpPortal *portal, double latitude, double longitude, double altitude, double accuracy, double speed, double heading, const char *description, qint64 timestamp_s, qint64 timestamp_ms,  gpointer data)
+{
+    Q_UNUSED(portal)
+
+    PortalPrivate *portalPrivate = static_cast<PortalPrivate*>(data);
+
+    portalPrivate->locationUpdated(latitude, longitude, altitude, accuracy, speed, heading, QString(description), timestamp_s, timestamp_ms);
+}
+
+}

--- a/libportal-qt/location.h
+++ b/libportal-qt/location.h
@@ -17,32 +17,37 @@
  * SPDX-License-Identifier: LGPL-3.0-only
  */
 
-#ifndef PORTAL_TEST_QT_H
-#define PORTAL_TEST_QT_H
+#ifndef LIBPORTALQT_LOCATION_H
+#define LIBPORTALQT_LOCATION_H
 
-#include <QMainWindow>
-#include "portal.h"
+#include <QFlags>
 
-class Ui_PortalTestQt;
-
-class PortalTestQt : public QMainWindow
+namespace Xdp
 {
-    Q_OBJECT
-public:
-    PortalTestQt(QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
-    ~PortalTestQt();
 
-    void updateLastOpenedFile(const QString &file);
-private Q_SLOTS:
-    void onUserInformationReceived(const Xdp::Response &response);
-    void onFileOpened(const Xdp::Response &response);
-    void onSessionInhibited(const Xdp::Response &response);
-
-private:
-    Ui_PortalTestQt *m_mainWindow;
-    int m_inhibitorId = -1;
-    QString m_fileToPrint;
-    int m_printToken;
+enum class LocationAccuracy
+{
+    None,
+    Country,
+    City,
+    Suspend,
+    Neighborhood,
+    Exact
 };
 
-#endif // PORTAL_TEST_QT_H
+enum class LocationMonitorFlag
+{
+    None = 0x0
+};
+Q_DECLARE_FLAGS(LocationMonitorFlags, LocationMonitorFlag)
+
+}
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(Xdp::LocationMonitorFlags)
+
+#endif // LIBPORTALQT_LOCATION_H
+
+
+
+
+

--- a/libportal-qt/meson.build
+++ b/libportal-qt/meson.build
@@ -1,0 +1,93 @@
+
+libportal_version = meson.project_version()
+
+add_languages('cpp', required : true)
+
+qt5_dep = dependency('qt5', modules: ['Core', 'Gui', 'PrintSupport'])
+
+src = [
+    'account.cpp',
+    'background.cpp',
+    'camera.cpp',
+    'email.cpp',
+    'filechooser.cpp',
+    'inhibit.cpp',
+    'location.cpp',
+    'notification.cpp',
+    'openuri.cpp',
+    'parent.cpp',
+    'portal.cpp',
+    'print.cpp',
+    'response.cpp',
+]
+
+pub_headers = [
+    'account.h',
+    'background.h',
+    'camera.h',
+    'email.h',
+    'filechooser.h',
+    'inhibit.h',
+    'libportalqt_export.h',
+    'location.h',
+    'notification.h',
+    'openuri.h',
+    'parent.h',
+    'portal.h',
+    'print.h',
+    'response.h'
+]
+
+priv_headers = [
+    'parent_p.h',
+    'portal_p.h'
+]
+
+moc = qt.preprocess(moc_headers : pub_headers + priv_headers,
+                    moc_extra_arguments: ['-DMAKES_MY_MOC_HEADER_COMPILE'])
+
+
+libportalqt = library ('LibPortalQt',
+                       [src, pub_headers, priv_headers, moc],
+                       soversion: 0,
+                       version: libportal_version,
+                       dependencies: [qt5_dep, gio_dep, gio_unix_dep],
+                       link_with: [libportal, libportal_qt5],
+                       include_directories: [top_inc, libportal_inc],
+                       install: true)
+
+libportalqt_dep = declare_dependency(sources: [src, pub_headers, priv_headers, moc],
+                                     include_directories: [top_inc, libportal_inc, libportalqt_inc],
+                                     dependencies: [qt5_dep, gio_dep, gio_unix_dep],
+                                     link_with: [libportal, libportal_qt5])
+
+install_headers(pub_headers, subdir: 'LibPortalQt')
+
+pkgconfig.generate(libportalqt,
+  description: 'Qt portal API wrappers',
+  name: 'libportal-qt',
+  requires: [ qt5_dep ],
+)
+
+#
+# CMake support
+#
+cmake_data = configuration_data()
+cmake_data.set('LIBDIR_FULL', join_paths(get_option('prefix'), get_option('libdir')))
+cmake_data.set('PREFIX', get_option('prefix'))
+cmake_data.set('VERSION', libportal_version)
+
+configure_file (input: 'cmake/LibPortalQtConfig.cmake.in',
+                output: 'LibPortalQtConfig.cmake',
+                configuration: cmake_data
+)
+configure_file (input: 'cmake/LibPortalQtConfigVersion.cmake.in',
+                output: 'LibPortalQtConfigVersion.cmake',
+                configuration: cmake_data
+)
+
+install_data (
+    join_paths(meson.current_build_dir(), 'LibPortalQtConfig.cmake'),
+    join_paths(meson.current_build_dir(), 'LibPortalQtConfigVersion.cmake'),
+    install_dir: join_paths(get_option('libdir'), 'cmake', 'LibPortalQt')
+)

--- a/libportal-qt/notification.cpp
+++ b/libportal-qt/notification.cpp
@@ -1,0 +1,437 @@
+/*
+ * Copyright (C) 2020-2021, Jan Grulich
+ *
+ * This file is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, version 3.0 of the
+ * License.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-only
+ */
+
+#include "notification.h"
+#include "portal.h"
+#include "parent.h"
+#include "parent_p.h"
+#include "portal_p.h"
+
+#include <QBuffer>
+
+namespace Xdp
+{
+
+class NotificationButtonPrivate
+{
+public:
+    NotificationButtonPrivate(const QString &label, const QString &action);
+    NotificationButtonPrivate(const NotificationButtonPrivate &other);
+    ~NotificationButtonPrivate() { };
+
+    QString m_label;
+    QString m_action;
+    QVariant m_target;
+};
+
+NotificationButtonPrivate::NotificationButtonPrivate(const QString &label, const QString &action)
+    : m_label(label)
+    , m_action(action)
+{
+}
+
+NotificationButtonPrivate::NotificationButtonPrivate(const NotificationButtonPrivate &other)
+    : NotificationButtonPrivate(other.m_label, other.m_action)
+{
+    m_target = other.m_target;
+}
+
+NotificationButton::NotificationButton(const QString &label, const QString &action)
+    : d_ptr(new NotificationButtonPrivate(label, action))
+{
+}
+
+NotificationButton::NotificationButton(const NotificationButton &other)
+    : NotificationButton(other.label(), other.action())
+{
+}
+
+NotificationButton::~NotificationButton()
+{
+}
+
+void NotificationButton::operator=(const NotificationButton &other)
+{
+    setLabel(other.label());
+    setAction(other.action());
+    setTarget(other.target());
+}
+
+bool NotificationButton::isValid() const
+{
+    Q_D(const NotificationButton);
+    return !d->m_label.isEmpty() && !d->m_action.isEmpty();
+}
+
+QString NotificationButton::label() const
+{
+    Q_D(const NotificationButton);
+    return d->m_label;
+}
+
+void NotificationButton::setLabel(const QString &label)
+{
+    Q_D(NotificationButton);
+    d->m_label = label;
+}
+
+QString NotificationButton::action() const
+{
+    Q_D(const NotificationButton);
+    return d->m_action;
+}
+
+void NotificationButton::setAction(const QString &action)
+{
+    Q_D(NotificationButton);
+    d->m_action = action;
+}
+
+QVariant NotificationButton::target() const
+{
+    Q_D(const NotificationButton);
+    return d->m_target;
+}
+
+void NotificationButton::setTarget(const QVariant &target)
+{
+    Q_D(NotificationButton);
+    d->m_target = target;
+}
+
+class NotificationPrivate
+{
+public:
+    explicit NotificationPrivate();
+    NotificationPrivate(const QString &title, const QString &body);
+    NotificationPrivate(const NotificationPrivate &other);
+    ~NotificationPrivate() { };
+
+    QString m_title;
+    QString m_body;
+    QString m_icon;
+    QPixmap m_pixmap;
+    QString m_priority;
+    QString m_defaultAction;
+    QVariant m_defaultTarget;
+    NotificationButtons m_buttons;
+};
+
+NotificationPrivate::NotificationPrivate()
+{
+}
+
+NotificationPrivate::NotificationPrivate(const QString &title, const QString &body)
+    : m_title(title)
+    , m_body(body)
+{
+}
+
+NotificationPrivate::NotificationPrivate(const NotificationPrivate &other)
+    : NotificationPrivate(other.m_title, other.m_body)
+{
+    m_icon = other.m_icon;
+    m_pixmap = other.m_pixmap;
+    m_priority = other.m_priority;
+    m_defaultAction = other.m_defaultAction;
+    m_defaultTarget = other.m_defaultTarget;
+    m_buttons = other.m_buttons;
+}
+
+Notification::Notification()
+    : d_ptr(new NotificationPrivate())
+{
+}
+
+Notification::Notification(const QString &label, const QString &action)
+    : d_ptr(new NotificationPrivate(label, action))
+{
+}
+
+Notification::Notification(const Notification &other)
+    : Notification(other.title(), other.body())
+{
+}
+
+Notification::~Notification()
+{
+}
+
+void Notification::operator=(const Notification &other)
+{
+    setTitle(other.title());
+    setBody(other.body());
+    setIcon(other.icon());
+    setPixmap(other.pixmap());
+    setPriority(other.priority());
+    setDefaultAction(other.defaultAction());
+    setDefaultActionTarget(other.defaultTarget());
+    for (const NotificationButton &button : other.buttons()) {
+        addButton(button);
+    }
+}
+
+bool Notification::isValid() const
+{
+    Q_D(const Notification);
+    return !d->m_title.isEmpty();
+}
+
+QString Notification::title() const
+{
+    Q_D(const Notification);
+    return d->m_title;
+}
+
+void Notification::setTitle(const QString &title)
+{
+    Q_D(Notification);
+    d->m_title = title;
+}
+
+QString Notification::body() const
+{
+    Q_D(const Notification);
+    return d->m_body;
+}
+
+void Notification::setBody(const QString &body)
+{
+    Q_D(Notification);
+    d->m_body = body;
+}
+
+QString Notification::icon() const
+{
+    Q_D(const Notification);
+    return d->m_icon;
+}
+
+void Notification::setIcon(const QString &icon)
+{
+    Q_D(Notification);
+    d->m_icon = icon;
+}
+
+QPixmap Notification::pixmap() const
+{
+    Q_D(const Notification);
+    return d->m_pixmap;
+}
+
+void Notification::setPixmap(const QPixmap &pixmap)
+{
+    Q_D(Notification);
+    d->m_pixmap = pixmap;
+}
+
+QString Notification::priority() const
+{
+    Q_D(const Notification);
+    return d->m_priority;
+}
+
+void Notification::setPriority(const QString &priority)
+{
+    Q_D(Notification);
+    d->m_priority = priority;
+}
+
+QString Notification::defaultAction() const
+{
+    Q_D(const Notification);
+    return d->m_defaultAction;
+}
+
+void Notification::setDefaultAction(const QString &defaultAction)
+{
+    Q_D(Notification);
+    d->m_defaultAction = defaultAction;
+}
+
+QVariant Notification::defaultTarget() const
+{
+    Q_D(const Notification);
+    return d->m_defaultTarget;
+}
+
+void Notification::setDefaultActionTarget(const QVariant &defaultTarget)
+{
+    Q_D(Notification);
+    d->m_defaultTarget = defaultTarget;
+}
+
+NotificationButtons Notification::buttons() const
+{
+    Q_D(const Notification);
+    return d->m_buttons;
+}
+
+void Notification::addButton(const NotificationButton &button)
+{
+    Q_D(Notification);
+    d->m_buttons << button;
+}
+
+static GVariant* convertVariant(const QVariant &variant)
+{
+    switch (variant.type()) {
+    case QVariant::Bool:
+        return g_variant_new_boolean(variant.toBool());
+    case QVariant::ByteArray:
+        return g_variant_new_bytestring(variant.toByteArray().data());
+    case QVariant::Double:
+        return g_variant_new_double(variant.toFloat());
+    case QVariant::Int:
+        return g_variant_new_int32(variant.toInt());
+    case QVariant::LongLong:
+        return g_variant_new_int64(variant.toLongLong());
+    case QVariant::String:
+        return g_variant_new_string(variant.toString().toUtf8().constData());
+    case QVariant::UInt:
+        return g_variant_new_uint32(variant.toUInt());
+    case QVariant::ULongLong:
+        return g_variant_new_uint64(variant.toULongLong());
+    default:
+        return nullptr;
+    }
+}
+
+static QVariant convertVariant(GVariant *variant)
+{
+    if (g_variant_is_of_type(variant, G_VARIANT_TYPE_BOOLEAN)) {
+        return QVariant::fromValue<bool>(g_variant_get_boolean(variant));
+    } else if (g_variant_is_of_type(variant, G_VARIANT_TYPE_BYTESTRING)) {
+        return QVariant::fromValue<QByteArray>(g_variant_get_bytestring(variant));
+    } else if (g_variant_is_of_type(variant, G_VARIANT_TYPE_DOUBLE)) {
+        return QVariant::fromValue<float>(g_variant_get_double(variant));
+    } else if (g_variant_is_of_type(variant, G_VARIANT_TYPE_INT32)) {
+        return QVariant::fromValue<int>(g_variant_get_int32(variant));
+    } else if (g_variant_is_of_type(variant, G_VARIANT_TYPE_INT64)) {
+        return QVariant::fromValue<long>(g_variant_get_int64(variant));
+    } else if (g_variant_is_of_type(variant, G_VARIANT_TYPE_STRING)) {
+        return QVariant::fromValue<QString>(g_variant_get_string(variant, nullptr));
+    } else if (g_variant_is_of_type(variant, G_VARIANT_TYPE_UINT32)) {
+        return QVariant::fromValue<uint>(g_variant_get_uint32(variant));
+    } else if (g_variant_is_of_type(variant, G_VARIANT_TYPE_UINT64)) {
+        return QVariant::fromValue<ulong>(g_variant_get_uint64(variant));
+    }
+
+    return QVariant();
+}
+
+GVariant *PortalPrivate::buttonsToVariant(const NotificationButtons &buttons)
+{
+    GVariantBuilder builder;
+    g_variant_builder_init(&builder, G_VARIANT_TYPE("aa{sv}"));
+
+    for (const NotificationButton &button : buttons) {
+        if (!button.isValid()) {
+            continue;
+        }
+
+        GVariantBuilder buttonBuilder;
+        g_variant_builder_init(&buttonBuilder, G_VARIANT_TYPE_VARDICT);
+        g_variant_builder_add(&buttonBuilder, "{sv}", "label", g_variant_new_string(button.label().toUtf8().constData()));
+        g_variant_builder_add(&buttonBuilder, "{sv}", "action", g_variant_new_string(button.action().toUtf8().constData()));
+
+        if (!button.target().isNull()) {
+            g_variant_builder_add(&buttonBuilder, "{sv}", "target", convertVariant(button.target()));
+        }
+
+        g_variant_builder_add(&builder, "@a{sv}", g_variant_builder_end(&buttonBuilder));
+    }
+
+    return g_variant_builder_end(&builder);
+}
+
+GVariant *PortalPrivate::notificationToVariant(const Notification &notification)
+{
+    GVariantBuilder builder;
+    g_variant_builder_init(&builder, G_VARIANT_TYPE_VARDICT);
+
+    if (!notification.title().isEmpty()) {
+        g_variant_builder_add(&builder, "{sv}", "title", g_variant_new_string(notification.title().toUtf8().constData()));
+    }
+
+    if (!notification.body().isEmpty()) {
+        g_variant_builder_add(&builder, "{sv}", "body", g_variant_new_string(notification.body().toUtf8().constData()));
+    }
+
+    if (!notification.icon().isEmpty()) {
+        g_variant_builder_add(&builder, "{sv}", "icon", g_icon_serialize(g_themed_icon_new(notification.icon().toUtf8().constData())));
+    } else if (!notification.pixmap().isNull()) {
+        g_autoptr(GBytes) bytes = nullptr;
+        QByteArray array;
+        QBuffer buffer(&array);
+        buffer.open(QIODevice::WriteOnly);
+        notification.pixmap().save(&buffer, "PNG");
+        bytes = g_bytes_new(array.data(), array.size());
+        g_variant_builder_add(&builder, "{sv}", "icon", g_icon_serialize(g_bytes_icon_new(bytes)));
+    }
+
+    if (!notification.defaultAction().isEmpty()) {
+        g_variant_builder_add(&builder, "{sv}", "default-action", g_variant_new_string(notification.defaultAction().toUtf8().constData()));
+    }
+
+    if (!notification.defaultTarget().isNull()) {
+        g_variant_builder_add(&builder, "{sv}", "default-action-target", convertVariant(notification.defaultTarget()));
+    }
+
+    if (!notification.buttons().isEmpty()) {
+        g_variant_builder_add(&builder, "{sv}", "buttons", buttonsToVariant(notification.buttons()));
+    }
+
+    return g_variant_builder_end(&builder);
+}
+
+void PortalPrivate::addNotification(const QString &id, const Notification &notification, NotificationFlags flags)
+{
+    xdp_portal_add_notification(m_xdpPortal, id.toUtf8().constData(), notificationToVariant(notification),
+                                static_cast<XdpNotificationFlags>((int)flags), nullptr /*cancellable*/, notificationAdded, this);
+}
+
+void PortalPrivate::notificationAdded(GObject *object, GAsyncResult *result, gpointer data)
+{
+    XdpPortal *xdpPortal = XDP_PORTAL(object);
+    PortalPrivate *portalPrivate = static_cast<PortalPrivate*>(data);
+    g_autoptr(GError) error = nullptr;
+
+    bool ret = xdp_portal_add_notification_finish(xdpPortal, result, &error);
+
+    Response response(ret, error);
+
+    portalPrivate->addNotificationResponse(response);
+}
+
+void PortalPrivate::removeNotification(const QString &id)
+{
+    xdp_portal_remove_notification(m_xdpPortal, id.toUtf8().constData());
+}
+
+void PortalPrivate::onNotificationActionInvoked(XdpPortal *portal, const char *id, const char *action, GVariant *parameter,  gpointer data)
+{
+    Q_UNUSED(portal)
+
+    PortalPrivate *portalPrivate = static_cast<PortalPrivate*>(data);
+
+    portalPrivate->notificationActionInvoked(QString(id), QString(action), convertVariant(parameter));
+}
+
+}

--- a/libportal-qt/notification.h
+++ b/libportal-qt/notification.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2020-2021, Jan Grulich
+ *
+ * This file is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, version 3.0 of the
+ * License.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-only
+ */
+
+#ifndef LIBPORTALQT_NOTIFICATION_H
+#define LIBPORTALQT_NOTIFICATION_H
+
+#include "libportalqt_export.h"
+
+#include <QFlags>
+#include <QString>
+#include <QPixmap>
+#include <QSharedPointer>
+
+namespace Xdp
+{
+
+enum class NotificationFlag
+{
+    None = 0x0
+};
+
+class NotificationButtonPrivate;
+class NotificationPrivate;
+
+class LIBPORTALQT_EXPORT NotificationButton
+{
+public:
+    NotificationButton(const QString &label, const QString &action);
+    NotificationButton(const NotificationButton &other);
+
+    ~NotificationButton();
+
+    void operator=(const NotificationButton &other);
+
+    bool isValid() const;
+
+    QString label() const;
+    void setLabel(const QString &label);
+
+    QString action() const;
+    void setAction(const QString &action);
+
+    QVariant target() const;
+    void setTarget(const QVariant &target);
+private:
+    Q_DECLARE_PRIVATE(NotificationButton)
+
+    const QScopedPointer<NotificationButtonPrivate> d_ptr;
+};
+
+typedef QList<NotificationButton> NotificationButtons;
+
+
+class LIBPORTALQT_EXPORT Notification
+{
+public:
+    explicit Notification();
+    Notification(const QString &title, const QString &body);
+    Notification(const Notification &other);
+    ~Notification();
+
+    void operator=(const Notification &other);
+
+    bool isValid() const;
+
+    QString title() const;
+    void setTitle(const QString &title);
+
+    QString body() const;
+    void setBody(const QString &body);
+
+    QString icon() const;
+    void setIcon(const QString &iconName);
+
+    QPixmap pixmap() const;
+    void setPixmap(const QPixmap &pixmap);
+
+    QString priority() const;
+    void setPriority(const QString &priority);
+
+    QString defaultAction() const;
+    void setDefaultAction(const QString &defaultAction);
+
+    QVariant defaultTarget() const;
+    void setDefaultActionTarget(const QVariant &target);
+
+    NotificationButtons buttons() const;
+    void addButton(const NotificationButton &button);
+private:
+
+    Q_DECLARE_PRIVATE(Notification)
+
+    const QScopedPointer<NotificationPrivate> d_ptr;
+};
+
+Q_DECLARE_FLAGS(NotificationFlags, NotificationFlag)
+}
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(Xdp::NotificationFlags)
+
+#endif // LIBPORTALQT_NOTIFICATION_H

--- a/libportal-qt/openuri.cpp
+++ b/libportal-qt/openuri.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2020-2021, Jan Grulich
+ *
+ * This file is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, version 3.0 of the
+ * License.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-only
+ */
+
+#include "portal.h"
+#include "parent.h"
+#include "parent_p.h"
+#include "portal_p.h"
+
+namespace Xdp
+{
+
+void PortalPrivate::openUri(const Parent &parent, const QString &uri, OpenUriFlags flags)
+{
+    xdp_portal_open_uri(m_xdpPortal, parent.d_ptr->m_xdpParent, uri.toUtf8().constData(), static_cast<XdpOpenUriFlags>((int)flags), nullptr, openedUri, this);
+}
+
+void PortalPrivate::openDirectory(const Parent &parent, const QString &uri, Xdp::OpenUriFlags flags)
+{
+    xdp_portal_open_directory(m_xdpPortal, parent.d_ptr->m_xdpParent, uri.toUtf8().constData(), static_cast<XdpOpenUriFlags>((int)flags), nullptr, openedDirectory, this);
+}
+
+void PortalPrivate::openedUri(GObject *object, GAsyncResult *result, gpointer data)
+{
+    XdpPortal *xdpPortal = XDP_PORTAL(object);
+    PortalPrivate *portalPrivate = static_cast<PortalPrivate*>(data);
+    g_autoptr(GError) error = nullptr;
+
+    bool ret = xdp_portal_open_uri_finish(xdpPortal, result, &error);
+
+    Response response(ret, error);
+
+    portalPrivate->openUriResponse(response);
+}
+
+void PortalPrivate::openedDirectory(GObject *object, GAsyncResult *result, gpointer data)
+{
+    XdpPortal *xdpPortal = XDP_PORTAL(object);
+    PortalPrivate *portalPrivate = static_cast<PortalPrivate*>(data);
+    g_autoptr(GError) error = nullptr;
+
+    bool ret = xdp_portal_open_directory_finish(xdpPortal, result, &error);
+
+    Response response(ret, error);
+
+    portalPrivate->openDirectoryResponse(response);
+}
+
+}

--- a/libportal-qt/openuri.h
+++ b/libportal-qt/openuri.h
@@ -17,32 +17,22 @@
  * SPDX-License-Identifier: LGPL-3.0-only
  */
 
-#ifndef PORTAL_TEST_QT_H
-#define PORTAL_TEST_QT_H
+#ifndef LIBPORTALQT_OPENURI_H
+#define LIBPORTALQT_OPENURI_H
 
-#include <QMainWindow>
-#include "portal.h"
+#include <QFlags>
 
-class Ui_PortalTestQt;
-
-class PortalTestQt : public QMainWindow
+namespace Xdp
 {
-    Q_OBJECT
-public:
-    PortalTestQt(QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
-    ~PortalTestQt();
 
-    void updateLastOpenedFile(const QString &file);
-private Q_SLOTS:
-    void onUserInformationReceived(const Xdp::Response &response);
-    void onFileOpened(const Xdp::Response &response);
-    void onSessionInhibited(const Xdp::Response &response);
-
-private:
-    Ui_PortalTestQt *m_mainWindow;
-    int m_inhibitorId = -1;
-    QString m_fileToPrint;
-    int m_printToken;
+enum class OpenUriFlag
+{
+    None = 0x0,
+    Ask = 0x1,
+    Writable = 0x2
 };
+Q_DECLARE_FLAGS(OpenUriFlags, OpenUriFlag)
+}
+Q_DECLARE_OPERATORS_FOR_FLAGS(Xdp::OpenUriFlags)
 
-#endif // PORTAL_TEST_QT_H
+#endif // LIBPORTALQT_OPENURI_H

--- a/libportal-qt/parent.cpp
+++ b/libportal-qt/parent.cpp
@@ -17,32 +17,33 @@
  * SPDX-License-Identifier: LGPL-3.0-only
  */
 
-#ifndef PORTAL_TEST_QT_H
-#define PORTAL_TEST_QT_H
+#include "parent.h"
+#include "parent_p.h"
 
-#include <QMainWindow>
-#include "portal.h"
-
-class Ui_PortalTestQt;
-
-class PortalTestQt : public QMainWindow
+namespace Xdp
 {
-    Q_OBJECT
-public:
-    PortalTestQt(QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
-    ~PortalTestQt();
 
-    void updateLastOpenedFile(const QString &file);
-private Q_SLOTS:
-    void onUserInformationReceived(const Xdp::Response &response);
-    void onFileOpened(const Xdp::Response &response);
-    void onSessionInhibited(const Xdp::Response &response);
+ParentPrivate::ParentPrivate(QWindow *window, Parent *q)
+    : m_xdpParent(xdp_parent_new_qt(window))
+    , q_ptr(q)
+{
+}
 
-private:
-    Ui_PortalTestQt *m_mainWindow;
-    int m_inhibitorId = -1;
-    QString m_fileToPrint;
-    int m_printToken;
-};
+ParentPrivate::~ParentPrivate()
+{
+    if (m_xdpParent) {
+        xdp_parent_free(m_xdpParent);
+    }
+}
 
-#endif // PORTAL_TEST_QT_H
+Parent::Parent(QWindow *window, QObject *parent)
+    : QObject(parent)
+    , d_ptr(new ParentPrivate(window, this))
+{
+}
+
+Parent::~Parent()
+{
+}
+
+}

--- a/libportal-qt/parent.h
+++ b/libportal-qt/parent.h
@@ -17,32 +17,33 @@
  * SPDX-License-Identifier: LGPL-3.0-only
  */
 
-#ifndef PORTAL_TEST_QT_H
-#define PORTAL_TEST_QT_H
+#ifndef LIBPORTALQT_PARENT_H
+#define LIBPORTALQT_PARENT_H
 
-#include <QMainWindow>
-#include "portal.h"
+#include <QObject>
+#include <QWindow>
 
-class Ui_PortalTestQt;
+#include "libportalqt_export.h"
 
-class PortalTestQt : public QMainWindow
+namespace Xdp
+{
+
+class ParentPrivate;
+
+class LIBPORTALQT_EXPORT Parent : public QObject
 {
     Q_OBJECT
 public:
-    PortalTestQt(QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
-    ~PortalTestQt();
-
-    void updateLastOpenedFile(const QString &file);
-private Q_SLOTS:
-    void onUserInformationReceived(const Xdp::Response &response);
-    void onFileOpened(const Xdp::Response &response);
-    void onSessionInhibited(const Xdp::Response &response);
+    explicit Parent(QWindow *window, QObject *parent = nullptr);
+    ~Parent();
 
 private:
-    Ui_PortalTestQt *m_mainWindow;
-    int m_inhibitorId = -1;
-    QString m_fileToPrint;
-    int m_printToken;
-};
+    Q_DECLARE_PRIVATE(Parent)
 
-#endif // PORTAL_TEST_QT_H
+    const QScopedPointer<ParentPrivate> d_ptr;
+
+    friend class PortalPrivate;
+};
+} // namespace Xdp
+
+#endif // LIBPORTALQT_PARENT_H

--- a/libportal-qt/parent_p.h
+++ b/libportal-qt/parent_p.h
@@ -17,32 +17,27 @@
  * SPDX-License-Identifier: LGPL-3.0-only
  */
 
-#ifndef PORTAL_TEST_QT_H
-#define PORTAL_TEST_QT_H
+#ifndef LIBPORTALQT_PARENT_P_H
+#define LIBPORTALQT_PARENT_P_H
 
-#include <QMainWindow>
-#include "portal.h"
+#include "portal_p.h"
 
-class Ui_PortalTestQt;
+namespace Xdp
+{
 
-class PortalTestQt : public QMainWindow
+class ParentPrivate : public QObject
 {
     Q_OBJECT
 public:
-    PortalTestQt(QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
-    ~PortalTestQt();
+    ParentPrivate(QWindow *window, Parent *q);
+    ~ParentPrivate();
 
-    void updateLastOpenedFile(const QString &file);
-private Q_SLOTS:
-    void onUserInformationReceived(const Xdp::Response &response);
-    void onFileOpened(const Xdp::Response &response);
-    void onSessionInhibited(const Xdp::Response &response);
+    XdpParent *m_xdpParent = nullptr;
 
-private:
-    Ui_PortalTestQt *m_mainWindow;
-    int m_inhibitorId = -1;
-    QString m_fileToPrint;
-    int m_printToken;
+    Q_DECLARE_PUBLIC(Parent)
+    Parent *q_ptr;
 };
 
-#endif // PORTAL_TEST_QT_H
+}
+
+#endif // LIBPORTALQT_PARENT_P_H

--- a/libportal-qt/portal.cpp
+++ b/libportal-qt/portal.cpp
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2020-2021, Jan Grulich
+ *
+ * This file is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, version 3.0 of the
+ * License.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-only
+ */
+
+#include "portal.h"
+#include "portal_p.h"
+
+#include <QFileInfo>
+#include <QPrinter>
+
+namespace Xdp
+{
+
+Q_GLOBAL_STATIC(PortalPrivate, globalPortal)
+
+PortalPrivate::PortalPrivate()
+    : m_xdpPortal(xdp_portal_new())
+{
+    g_signal_connect(m_xdpPortal, "session-state-changed", G_CALLBACK(onSessionStateChanged), this);
+    g_signal_connect(m_xdpPortal, "location-updated", G_CALLBACK(onLocationUpdated), this);
+    g_signal_connect(m_xdpPortal, "notification-action-invoked", G_CALLBACK(onNotificationActionInvoked), this);
+}
+
+PortalPrivate::~PortalPrivate()
+{
+    if (m_xdpPortal) {
+        g_object_unref(m_xdpPortal);
+    }
+}
+
+// Account portal
+void getUserInformation(const Parent &parent, const QString &reason, UserInformationFlags flags)
+{
+    globalPortal->getUserInformation(parent, reason, flags);
+}
+
+// Background portal
+void requestBackground(const Parent &parent, const QString &reason, const QStringList &commandline, BackgroundFlags flags)
+{
+    globalPortal->requestBackground(parent, reason, commandline, flags);
+}
+
+// Camera portal
+void accessCamera(const Parent &parent, CameraFlags flags)
+{
+    globalPortal->accessCamera(parent, flags);
+}
+
+int openPipewireRemoteForCamera()
+{
+    return globalPortal->openPipewireRemoteForCamera();
+}
+
+// Email portal
+void composeEmail(const Parent &parent, const QStringList &addresses, const QStringList &cc,
+                       const QStringList &bcc, const QString &subject, const QString &body,
+                       const QStringList &attachments, EmailFlags flags)
+{
+    globalPortal->composeEmail(parent, addresses, cc, bcc, subject, body, attachments, flags);
+}
+
+// FileChooser portal
+void openFile(const Parent &parent, const QString &title, const FileChooserFilterList &filters, const FileChooserFilter &currentFilter,
+                   const FileChooserChoices &choices, OpenFileFlags flags)
+{
+    globalPortal->openFile(parent, title, filters, currentFilter, choices, flags);
+}
+
+void saveFile(const Parent &parent, const QString &title, const QString &currentName, const QString &currentFolder, const QString &currentFile,
+                   const FileChooserFilterList &filters, const FileChooserFilter &currentFilter, const FileChooserChoices &choices, SaveFileFlags flags)
+{
+    globalPortal->saveFile(parent, title, currentName, currentFolder, currentFile, filters, currentFilter, choices, flags);
+}
+
+void saveFiles(const Parent &parent, const QString &title, const QString &currentFolder, const QStringList &files,
+                    const FileChooserChoices &choices, SaveFileFlags flags)
+{
+    globalPortal->saveFiles(parent, title, currentFolder, files, choices, flags);
+}
+
+// Inhibit portal
+void sessionInhibit(const Parent &parent, const QString &reason, InhibitFlags flags)
+{
+    globalPortal->sessionInhibit(parent, reason, flags);
+}
+
+void sessionUninhibit(int id)
+{
+    globalPortal->sessionUninhibit(id);
+}
+
+void sessionMonitorStart(const Parent &parent, SessionMonitorFlags flags)
+{
+    globalPortal->sessionMonitorStart(parent, flags);
+}
+
+void sessionMonitorStop()
+{
+    globalPortal->sessionMonitorStop();
+}
+
+void sessionMonitorQueryEndResponse()
+{
+    globalPortal->sessionMonitorQueryEndResponse();
+}
+
+// Location portal
+void locationMonitorStart(const Parent &parent, uint distanceThreshold, uint timeThreshold, LocationAccuracy accuracy, LocationMonitorFlags flags)
+{
+    globalPortal->locationMonitorStart(parent, distanceThreshold, timeThreshold, accuracy, flags);
+}
+
+void locationMonitorStop()
+{
+    globalPortal->locationMonitorStop();
+}
+
+// Notification portal
+void addNotification(const QString& id, const Notification& notification, NotificationFlags flags)
+{
+    globalPortal->addNotification(id, notification, flags);
+}
+
+void removeNotification(const QString& id)
+{
+    globalPortal->removeNotification(id);
+}
+
+// OpenURI portal
+void openUri(const Parent &parent, const QString &uri, OpenUriFlags flags)
+{
+    globalPortal->openUri(parent, uri, flags);
+}
+
+void openDirectory(const Parent &parent, const QString &uri, OpenUriFlags flags)
+{
+    globalPortal->openDirectory(parent, uri, flags);
+}
+
+// Print portal
+void preparePrint(const Parent &parent, const QString &title, const QPrinter &printer, PrintFlags flags)
+{
+    globalPortal->preparePrint(parent, title, printer, flags);
+}
+
+void printFile(const Parent &parent, const QString &title, int token, const QString &file, PrintFlags flags)
+{
+    globalPortal->printFile(parent, title, token, file, flags);
+}
+
+bool isSandboxed()
+{
+    return QFileInfo::exists(QStringLiteral("/.flatpak-info")) || qEnvironmentVariableIsSet("SNAP");
+}
+
+Notifier *notifier()
+{
+    return globalPortal;
+}
+
+}
+

--- a/libportal-qt/portal.h
+++ b/libportal-qt/portal.h
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2020-2021, Jan Grulich
+ *
+ * This file is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, version 3.0 of the
+ * License.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-only
+ */
+
+#ifndef LIBPORTALQT_PORTAL_H
+#define LIBPORTALQT_PORTAL_H
+
+#include <QObject>
+
+#include "account.h"
+#include "background.h"
+#include "camera.h"
+#include "email.h"
+#include "libportalqt_export.h"
+#include "filechooser.h"
+#include "inhibit.h"
+#include "location.h"
+#include "notification.h"
+#include "openuri.h"
+#include "parent.h"
+#include "print.h"
+#include "response.h"
+
+class QPrinter;
+
+namespace Xdp
+{
+
+class LIBPORTALQT_EXPORT Notifier : public QObject
+{
+    Q_OBJECT
+Q_SIGNALS:
+    // Account portal
+    void getUserInformationResponse(const Response &response);
+
+    // Background portal
+    void requestBackgroundResponse(const Response &response);
+
+    // Camera portal
+    void accessCameraResponse(const Response &response);
+
+    // Email portal
+    void composeEmailResponse(const Response &response);
+
+    // FileChooser portal
+    void openFileResponse(const Response &response);
+    void saveFileResponse(const Response &response);
+    void saveFilesResponse(const Response &response);
+
+    // Inhibit portal
+    void sessionInhibitResponse(const Response &response);
+    void sessionMonitorStartResponse(const Response &response);
+    void sessionStateChanged(bool screenSaverActive, LoginSessionState currentState);
+
+    // Location portal
+    void locationMonitorStartResponse(const Response &response);
+    void locationUpdated(double latitude, double longitude, double altitude, double accuracy, double speed, double heading, const QString &description, qint64 timestamp_s, qint64 timestamp_ms);
+
+    // Notification portal
+    void addNotificationResponse(const Response &response);
+    void notificationActionInvoked(const QString &id, const QString &action, const QVariant &parameter);
+
+     // OpenURI portal
+    void openUriResponse(const Response &response);
+    void openDirectoryResponse(const Response &response);
+
+    // Print portal
+    void preparePrintResponse(const Response &response);
+    void printFileResponse(const Response &response);
+};
+
+    // Account portal
+    LIBPORTALQT_EXPORT Q_INVOKABLE void getUserInformation(const Parent &parent, const QString &reason, UserInformationFlags flags);
+
+    // Background portal
+    LIBPORTALQT_EXPORT Q_INVOKABLE void requestBackground(const Parent &parent, const QString &reason, const QStringList &commandline, BackgroundFlags flags);
+
+    // Camera portal
+    LIBPORTALQT_EXPORT Q_INVOKABLE void accessCamera(const Parent &parent, CameraFlags flags);
+    LIBPORTALQT_EXPORT Q_INVOKABLE int openPipewireRemoteForCamera();
+
+    // Email portal
+    LIBPORTALQT_EXPORT Q_INVOKABLE void composeEmail(const Parent &parent, const QStringList &addresses, const QStringList &cc,
+                                                     const QStringList &bcc, const QString &subject, const QString &body,
+                                                     const QStringList &attachments, EmailFlags flags);
+
+    // FileChooser portal
+    LIBPORTALQT_EXPORT Q_INVOKABLE void openFile(const Parent &parent, const QString &title, const FileChooserFilterList &filters, const FileChooserFilter &currentFilter,
+                                                 const FileChooserChoices &choices, OpenFileFlags flags);
+    LIBPORTALQT_EXPORT Q_INVOKABLE void saveFile(const Parent &parent, const QString &title, const QString &currentName, const QString &currentFolder, const QString &currentFile,
+                                                 const FileChooserFilterList &filters, const FileChooserFilter &currentFilter, const FileChooserChoices &choices, SaveFileFlags flags);
+    LIBPORTALQT_EXPORT Q_INVOKABLE void saveFiles(const Parent &parent, const QString &title, const QString &currentFolder, const QStringList &files,
+                                                  const FileChooserChoices &choices, SaveFileFlags flags);
+
+    // Inhibit portal
+    LIBPORTALQT_EXPORT Q_INVOKABLE void sessionInhibit(const Parent &parent, const QString &reason, InhibitFlags flags);
+    LIBPORTALQT_EXPORT Q_INVOKABLE void sessionUninhibit(int id);
+    LIBPORTALQT_EXPORT Q_INVOKABLE void sessionMonitorStart(const Parent &parent, SessionMonitorFlags flags);
+    LIBPORTALQT_EXPORT Q_INVOKABLE void sessionMonitorStop();
+    LIBPORTALQT_EXPORT Q_INVOKABLE void sessionMonitorQueryEndResponse();
+
+    // Location portal
+    LIBPORTALQT_EXPORT Q_INVOKABLE void locationMonitorStart(const Parent &parent, uint distanceThreshold, uint timeThreshold, LocationAccuracy accuracy, LocationMonitorFlags flags);
+    LIBPORTALQT_EXPORT Q_INVOKABLE void locationMonitorStop();
+
+    // Notification portal
+    LIBPORTALQT_EXPORT Q_INVOKABLE void addNotification(const QString &id, const Notification &notification, NotificationFlags flags);
+    LIBPORTALQT_EXPORT Q_INVOKABLE void removeNotification(const QString &id);
+
+    // OpenURI portal
+    LIBPORTALQT_EXPORT Q_INVOKABLE void openUri(const Parent &parent, const QString &uri, OpenUriFlags flags);
+    LIBPORTALQT_EXPORT Q_INVOKABLE void openDirectory(const Parent &parent, const QString &uri, OpenUriFlags flags);
+
+    // Print portal
+    LIBPORTALQT_EXPORT Q_INVOKABLE void preparePrint(const Parent &parent, const QString &title, const QPrinter &printer, PrintFlags flags);
+    LIBPORTALQT_EXPORT Q_INVOKABLE void printFile(const Parent &parent, const QString &title, int token, const QString &file, PrintFlags flags);
+
+    // Helpers
+    LIBPORTALQT_EXPORT Q_INVOKABLE bool isSandboxed();
+
+    LIBPORTALQT_EXPORT Q_INVOKABLE Notifier *notifier();
+} // namespace Xdp
+
+#endif // LIBPORTALQT_PORTAL_H

--- a/libportal-qt/portal_p.h
+++ b/libportal-qt/portal_p.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2020-2021, Jan Grulich
+ *
+ * This file is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, version 3.0 of the
+ * License.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-only
+ */
+
+#ifndef LIBPORTALQT_PORTAL_P_H
+#define LIBPORTALQT_PORTAL_P_H
+
+#include "portal.h"
+
+#undef signals
+#include "portal-qt5.h"
+#define signals Q_SIGNALS
+
+class QPrinter;
+
+namespace Xdp
+{
+
+class PortalPrivate : public Xdp::Notifier
+{
+    Q_OBJECT
+public:
+    PortalPrivate();
+    virtual ~PortalPrivate();
+
+    // Account portal
+    void getUserInformation(const Parent &parent, const QString &reason, UserInformationFlags flags);
+    static void gotUserInformation(GObject *object, GAsyncResult *result, gpointer data);
+
+    // Background portal
+    void requestBackground(const Parent &parent, const QString &reason, const QStringList &commandline, BackgroundFlags flags);
+    static void requestedBackground(GObject *object, GAsyncResult *result, gpointer data);
+
+    // Camera portal
+    void accessCamera(const Parent &parent, CameraFlags flags);
+    static void accessedCamera(GObject *object, GAsyncResult *result, gpointer data);
+
+    int openPipewireRemoteForCamera();
+
+    // Email
+    void composeEmail(const Parent &parent, const QStringList &addresses, const QStringList &cc,
+                      const QStringList &bcc, const QString &subject, const QString &body,
+                      const QStringList &attachments, EmailFlags flags);
+    static void composedEmail(GObject *object, GAsyncResult *result, gpointer data);
+
+    // FileChooser portal
+    void openFile(const Parent &parent, const QString &title, const FileChooserFilterList &filters, const FileChooserFilter &currentFilter,
+                  const FileChooserChoices &choices, OpenFileFlags flags);
+    static void openedFile(GObject *object, GAsyncResult *result, gpointer data);
+
+    void saveFile(const Parent &parent, const QString &title, const QString &currentName, const QString &currentFolder, const QString &currentFile,
+                  const FileChooserFilterList &filters, const FileChooserFilter &currentFilter, const FileChooserChoices &choices, SaveFileFlags flags);
+    static void savedFile(GObject *object, GAsyncResult *result, gpointer data);
+
+    void saveFiles(const Parent &parent, const QString &title, const QString &currentFolder, const QStringList &files,
+                   const FileChooserChoices &choices, SaveFileFlags flags);
+    static void savedFiles(GObject *object, GAsyncResult *result, gpointer data);
+
+    static GVariant *filterToVariant(const FileChooserFilter &filter);
+    static GVariant *filterListToVariant(const FileChooserFilterList &filters);
+    static GVariant *choiceToVariant(const FileChooserChoice &choice);
+    static GVariant *choicesToVariant(const FileChooserChoices &choices);
+    static GVariant *filesToVariant(const QStringList &files);
+
+    // Inhibit portal
+    void sessionInhibit(const Parent &parent, const QString &reason, InhibitFlags flags);
+    static void sessionInhibited(GObject *object, GAsyncResult *result, gpointer data);
+    void sessionUninhibit(int id);
+    void sessionMonitorStart(const Parent &parent, SessionMonitorFlags flags);
+    static void sessionMonitorStarted(GObject *object, GAsyncResult *result, gpointer data);
+    void sessionMonitorStop();
+    void sessionMonitorQueryEndResponse();
+    static void onSessionStateChanged(XdpPortal *portal, gboolean screenSaverActive, XdpLoginSessionState currentState, gpointer data);
+
+    // Location portal
+    void locationMonitorStart(const Parent &parent, uint distanceThreshold, uint timeThreshold, LocationAccuracy accuracy,
+                              LocationMonitorFlags flags);
+    static void locationMonitorStarted(GObject *object, GAsyncResult *result, gpointer data);
+    void locationMonitorStop();
+    static void onLocationUpdated(XdpPortal *portal, double latitude, double longitude, double altitude, double accuracy, double speed, double heading, const char *description, qint64 timestamp_s, qint64 timestamp_ms,  gpointer data);
+
+    // Notification portal
+    void addNotification(const QString &id, const Notification &notification, NotificationFlags flags);
+    static void notificationAdded(GObject *object, GAsyncResult *result, gpointer data);
+    void removeNotification(const QString &id);
+    static void onNotificationActionInvoked(XdpPortal *portal, const char *id, const char *action, GVariant *parameter, gpointer data);
+
+    static GVariant *buttonsToVariant(const NotificationButtons &buttons);
+    static GVariant *notificationToVariant(const Notification &notification);
+
+    // OpenURI portal
+    void openUri(const Parent &parent, const QString &uri, OpenUriFlags flags);
+    static void openedUri(GObject *object, GAsyncResult *result, gpointer data);
+
+    // Print portal
+    void preparePrint(const Parent &parent, const QString &title, const QPrinter &printer, PrintFlags flags);
+    static void preparedPrint(GObject *object, GAsyncResult *result, gpointer data);
+    void printFile(const Parent &parent, const QString &title, int token, const QString &file, PrintFlags flags);
+    static void printedFile(GObject *object, GAsyncResult *result, gpointer data);
+
+    void openDirectory(const Parent &parent, const QString &uri, OpenUriFlags flags);
+    static void openedDirectory(GObject *object, GAsyncResult *result, gpointer data);
+private:
+    XdpPortal *m_xdpPortal = nullptr;
+};
+}
+
+#endif // LIBPORTALQT_PORTAL_P_H

--- a/libportal-qt/print.cpp
+++ b/libportal-qt/print.cpp
@@ -1,0 +1,446 @@
+/*
+ * Copyright (C) 2020-2021, Jan Grulich
+ *
+ * This file is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, version 3.0 of the
+ * License.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-only
+ */
+
+#include "portal.h"
+#include "parent.h"
+#include "parent_p.h"
+#include "portal_p.h"
+
+#include <QPrinter>
+#include <QPageSize>
+#include <QUrl>
+
+namespace Xdp
+{
+
+// INFO: code below is copied from Qt as there is no public API for converting key to PageSizeId
+// Standard sizes data
+struct StandardPageSize {
+    QPageSize::PageSizeId id;
+    const char *mediaOption; // PPD standard mediaOption ID
+};
+
+// Standard page sizes taken from the Postscript PPD Standard v4.3
+// See https://www-cdf.fnal.gov/offline/PostScript/5003.PPD_Spec_v4.3.pdf
+// Excludes all Transverse and Rotated sizes
+// NB!This table needs to be in sync with QPageSize::PageSizeId
+const static StandardPageSize qt_pageSizes[] = {
+
+    // Existing Qt sizes including ISO, US, ANSI and other standards
+    {QPageSize::A4, "A4"},
+    {QPageSize::B5, "ISOB5"},
+    {QPageSize::Letter, "Letter"},
+    {QPageSize::Legal, "Legal"},
+    {QPageSize::Executive, "Executive.7.5x10in"}, // Qt size differs from Postscript / Windows
+    {QPageSize::A0, "A0"},
+    {QPageSize::A1, "A1"},
+    {QPageSize::A2, "A2"},
+    {QPageSize::A3, "A3"},
+    {QPageSize::A5, "A5"},
+    {QPageSize::A6, "A6"},
+    {QPageSize::A7, "A7"},
+    {QPageSize::A8, "A8"},
+    {QPageSize::A9, "A9"},
+    {QPageSize::B0, "ISOB0"},
+    {QPageSize::B1, "ISOB1"},
+    {QPageSize::B10, "ISOB10"},
+    {QPageSize::B2, "ISOB2"},
+    {QPageSize::B3, "ISOB3"},
+    {QPageSize::B4, "ISOB4"},
+    {QPageSize::B6, "ISOB6"},
+    {QPageSize::B7, "ISOB7"},
+    {QPageSize::B8, "ISOB8"},
+    {QPageSize::B9, "ISOB9"},
+    {QPageSize::C5E, "EnvC5"},
+    {QPageSize::Comm10E, "Env10"},
+    {QPageSize::DLE, "EnvDL"},
+    {QPageSize::Folio, "Folio"},
+    {QPageSize::Ledger, "Ledger"},
+    {QPageSize::Tabloid, "Tabloid"},
+    {QPageSize::Custom, "Custom"}, // Special case to keep in sync with QPageSize::PageSizeId
+
+    // ISO Standard Sizes
+    {QPageSize::A10, "A10"},
+    {QPageSize::A3Extra, "A3Extra"},
+    {QPageSize::A4Extra, "A4Extra"},
+    {QPageSize::A4Plus, "A4Plus"},
+    {QPageSize::A4Small, "A4Small"},
+    {QPageSize::A5Extra, "A5Extra"},
+    {QPageSize::B5Extra, "ISOB5Extra"},
+
+    // JIS Standard Sizes
+    {QPageSize::JisB0, "B0"},
+    {QPageSize::JisB1, "B1"},
+    {QPageSize::JisB2, "B2"},
+    {QPageSize::JisB3, "B3"},
+    {QPageSize::JisB4, "B4"},
+    {QPageSize::JisB5, "B5"},
+    {QPageSize::JisB6, "B6"},
+    {QPageSize::JisB7, "B7"},
+    {QPageSize::JisB8, "B8"},
+    {QPageSize::JisB9, "B9"},
+    {QPageSize::JisB10, "B10"},
+
+    // ANSI / US Standard sizes
+    {QPageSize::AnsiC, "AnsiC"},
+    {QPageSize::AnsiD, "AnsiD"},
+    {QPageSize::AnsiE, "AnsiE"},
+    {QPageSize::LegalExtra, "LegalExtra"},
+    {QPageSize::LetterExtra, "LetterExtra"},
+    {QPageSize::LetterPlus, "LetterPlus"},
+    {QPageSize::LetterSmall, "LetterSmall"},
+    {QPageSize::TabloidExtra, "TabloidExtra"},
+
+    // Architectural sizes
+    {QPageSize::ArchA, "ARCHA"},
+    {QPageSize::ArchB, "ARCHB"},
+    {QPageSize::ArchC, "ARCHC"},
+    {QPageSize::ArchD, "ARCHD"},
+    {QPageSize::ArchE, "ARCHE"},
+
+    // Inch-based Sizes
+    {QPageSize::Imperial7x9, "7x9"},
+    {QPageSize::Imperial8x10, "8x10"},
+    {QPageSize::Imperial9x11, "9x11"},
+    {QPageSize::Imperial9x12, "9x12"},
+    {QPageSize::Imperial10x11, "10x11"},
+    {QPageSize::Imperial10x13, "10x13"},
+    {QPageSize::Imperial10x14, "10x14"},
+    {QPageSize::Imperial12x11, "12x11"},
+    {QPageSize::Imperial15x11, "15x11"},
+
+    // Other Page Sizes
+    {QPageSize::ExecutiveStandard, "Executive"}, // Qt size differs from Postscript / Windows
+    {QPageSize::Note, "Note"},
+    {QPageSize::Quarto, "Quarto"},
+    {QPageSize::Statement, "Statement"},
+    {QPageSize::SuperA, "SuperA"},
+    {QPageSize::SuperB, "SuperB"},
+    {QPageSize::Postcard, "Postcard"},
+    {QPageSize::DoublePostcard, "DoublePostcard"},
+    {QPageSize::Prc16K, "PRC16K"},
+    {QPageSize::Prc32K, "PRC32K"},
+    {QPageSize::Prc32KBig, "PRC32KBig"},
+
+    // Fan Fold Sizes
+    {QPageSize::FanFoldUS, "FanFoldUS"},
+    {QPageSize::FanFoldGerman, "FanFoldGerman"},
+    {QPageSize::FanFoldGermanLegal, "FanFoldGermanLegal"},
+
+    // ISO Envelopes
+    {QPageSize::EnvelopeB4, "EnvISOB4"},
+    {QPageSize::EnvelopeB5, "EnvISOB5"},
+    {QPageSize::EnvelopeB6, "EnvISOB6"},
+    {QPageSize::EnvelopeC0, "EnvC0"},
+    {QPageSize::EnvelopeC1, "EnvC1"},
+    {QPageSize::EnvelopeC2, "EnvC2"},
+    {QPageSize::EnvelopeC3, "EnvC3"},
+    {QPageSize::EnvelopeC4, "EnvC4"},
+    {QPageSize::EnvelopeC6, "EnvC6"},
+    {QPageSize::EnvelopeC65, "EnvC65"},
+    {QPageSize::EnvelopeC7, "EnvC7"},
+
+    // US Envelopes
+    {QPageSize::Envelope9, "Env9"},
+    {QPageSize::Envelope11, "Env11"},
+    {QPageSize::Envelope12, "Env12"},
+    {QPageSize::Envelope14, "Env14"},
+    {QPageSize::EnvelopeMonarch, "EnvMonarch"},
+    {QPageSize::EnvelopePersonal, "EnvPersonal"},
+
+    // Other Envelopes
+    {QPageSize::EnvelopeChou3, "EnvChou3"},
+    {QPageSize::EnvelopeChou4, "EnvChou4"},
+    {QPageSize::EnvelopeInvite, "EnvInvite"},
+    {QPageSize::EnvelopeItalian, "EnvItalian"},
+    {QPageSize::EnvelopeKaku2, "EnvKaku2"},
+    {QPageSize::EnvelopeKaku3, "EnvKaku3"},
+    {QPageSize::EnvelopePrc1, "EnvPRC1"},
+    {QPageSize::EnvelopePrc2, "EnvPRC2"},
+    {QPageSize::EnvelopePrc3, "EnvPRC3"},
+    {QPageSize::EnvelopePrc4, "EnvPRC4"},
+    {QPageSize::EnvelopePrc5, "EnvPRC5"},
+    {QPageSize::EnvelopePrc6, "EnvPRC6"},
+    {QPageSize::EnvelopePrc7, "EnvPRC7"},
+    {QPageSize::EnvelopePrc8, "EnvPRC8"},
+    {QPageSize::EnvelopePrc9, "EnvPRC9"},
+    {QPageSize::EnvelopePrc10, "EnvPRC10"},
+    {QPageSize::EnvelopeYou4, "EnvYou4"}};
+
+// Return key name for PageSize
+static QString qt_keyForPageSizeId(QPageSize::PageSizeId id)
+{
+    return QString::fromLatin1(qt_pageSizes[id].mediaOption);
+}
+
+static GVariant *settingsFromPrinter(const QPrinter &printer)
+{
+    GVariantBuilder builder;
+    g_variant_builder_init(&builder, G_VARIANT_TYPE_VARDICT);
+
+    g_variant_builder_add(&builder, "{sv}", "n-copies", g_variant_new_int32(printer.copyCount()));
+
+    QString orientation = QStringLiteral("landscape");
+    if (printer.pageLayout().orientation() == QPageLayout::Portrait) {
+        orientation = QStringLiteral("portrait");
+    }
+    g_variant_builder_add(&builder, "{sv}", "orientation", g_variant_new_string(orientation.toUtf8().constData()));
+
+
+
+    if (printer.resolution()) {
+        g_variant_builder_add(&builder, "{sv}", "resolution", g_variant_new_int32(printer.resolution()));
+    }
+
+    g_variant_builder_add(&builder, "{sv}", "use-color", g_variant_new_string(printer.colorMode() == QPrinter::Color ? "yes" : "no"));
+
+    QString duplex = QStringLiteral("simplex");
+    if (printer.duplex() == QPrinter::DuplexShortSide) {
+        duplex = QStringLiteral("horizontal");
+    } else if (printer.duplex() == QPrinter::DuplexLongSide) {
+        duplex = QStringLiteral("vertical");
+    }
+    g_variant_builder_add(&builder, "{sv}", "duplex", g_variant_new_string(duplex.toUtf8().constData()));
+
+    g_variant_builder_add(&builder, "{sv}", "collate", g_variant_new_string(printer.collateCopies() ? "yes" : "no"));
+    g_variant_builder_add(&builder, "{sv}", "reverse", g_variant_new_string(printer.pageOrder() == QPrinter::LastPageFirst ? "yes" : "no"));
+
+    QString range = QStringLiteral("all");
+    if (printer.printRange() == QPrinter::Selection) {
+        range = QStringLiteral("selection");
+    } else if (printer.printRange() == QPrinter::CurrentPage) {
+        range = QStringLiteral("current");
+    } else if (printer.printRange() == QPrinter::PageRange) {
+        range = QStringLiteral("ranges");
+    }
+    g_variant_builder_add(&builder, "{sv}", "print-pages", g_variant_new_string(range.toUtf8().constData()));
+
+    if (printer.fromPage() || printer.toPage()) {
+        g_variant_builder_add(&builder, "{sv}", "page-ranges", g_variant_new_string(QStringLiteral("%1-%2").arg(printer.fromPage()).arg(printer.toPage()).toUtf8().constData()));
+    }
+
+    g_variant_builder_add(&builder, "{sv}", "output-file-format", g_variant_new_string("pdf"));
+    g_variant_builder_add(&builder, "{sv}", "output-uri", g_variant_new_string(printer.outputFileName().toUtf8().constData()));
+
+    return g_variant_builder_end(&builder);
+}
+
+
+static GVariant *pageSetupFromPrinter(const QPrinter &printer)
+{
+    GVariantBuilder builder;
+    g_variant_builder_init(&builder, G_VARIANT_TYPE_VARDICT);
+
+    const QPageLayout layout = printer.pageLayout();
+    QString orientation = QStringLiteral("landscape");
+    if (printer.pageLayout().orientation() == QPageLayout::Portrait) {
+        orientation = QStringLiteral("portrait");
+    }
+    g_variant_builder_add(&builder, "{sv}", "Orientation", g_variant_new_string(orientation.toUtf8().constData()));
+    g_variant_builder_add(&builder, "{sv}", "PPDName", g_variant_new_string(qt_keyForPageSizeId(layout.pageSize().id()).toUtf8().constData()));
+    g_variant_builder_add(&builder, "{sv}", "DisplayName", g_variant_new_string(layout.pageSize().name().toUtf8().constData()));
+    g_variant_builder_add(&builder, "{sv}", "Width", g_variant_new_double(layout.pageSize().size(QPageSize::Millimeter).width()));
+    g_variant_builder_add(&builder, "{sv}", "Height", g_variant_new_double(layout.pageSize().size(QPageSize::Millimeter).height()));
+
+    const QMarginsF pageMargins = layout.margins(QPageLayout::Millimeter);
+    g_variant_builder_add(&builder, "{sv}", "MarginTop", g_variant_new_double(pageMargins.top()));
+    g_variant_builder_add(&builder, "{sv}", "MarginBottom", g_variant_new_double(pageMargins.bottom()));
+    g_variant_builder_add(&builder, "{sv}", "MarginLeft", g_variant_new_double(pageMargins.left()));
+    g_variant_builder_add(&builder, "{sv}", "MarginRight", g_variant_new_double(pageMargins.right()));
+
+    return g_variant_builder_end(&builder);
+}
+
+void PortalPrivate::preparePrint(const Parent &parent, const QString &title, const QPrinter &printer, PrintFlags flags)
+{
+    // FIXME: not processed for missing API or private API
+    // Settings: paper-format, paper-width, paper-height, default-source, quality, media-type, dither, scale,
+    //           page-set, finishings, number-up, number-up-layout, output-bin, resolution-x, resolution-y, printer-lpi
+    //           output-file-format
+    xdp_portal_prepare_print(m_xdpPortal, parent.d_ptr->m_xdpParent, title.toUtf8().constData(), settingsFromPrinter(printer),
+                             pageSetupFromPrinter(printer), static_cast<XdpPrintFlags>((int)flags), nullptr, preparedPrint, this);
+}
+
+void PortalPrivate::preparedPrint(GObject *object, GAsyncResult *result, gpointer data)
+{
+    XdpPortal *xdpPortal = XDP_PORTAL(object);
+    PortalPrivate *portalPrivate = static_cast<PortalPrivate*>(data);
+    g_autoptr(GError) error = nullptr;
+    g_autoptr(GVariant) ret = xdp_portal_prepare_print_finish(xdpPortal, result, &error);
+
+    if (ret) {
+        QVariantMap responseData;
+        guint token = 0;
+        g_autoptr(GVariant) settings;
+        g_autoptr(GVariant) pageSetup;
+
+        QVariantMap settingsMap;
+        QVariantMap pageSetupMap;
+
+        settings = g_variant_lookup_value(ret, "settings", G_VARIANT_TYPE_DICTIONARY);
+
+        if (settings) {
+            gint nCopies = 0;
+            if (g_variant_lookup(settings, "n-copies", "i", &nCopies)) {
+                settingsMap.insert(QStringLiteral("n-copies"), nCopies);
+            }
+
+            g_autofree gchar *orientation = nullptr;
+            if (g_variant_lookup(settings, "orientation", "s", &orientation)) {
+                settingsMap.insert(QStringLiteral("orientation"), orientation);
+            }
+
+            gint resolution = 0;
+            if (g_variant_lookup(settings, "resolution", "i", &resolution)) {
+                settingsMap.insert(QStringLiteral("resolution"), resolution);
+            }
+
+            g_autofree gchar *useColor = nullptr;
+            if (g_variant_lookup(settings, "use-color", "s", &useColor)) {
+                settingsMap.insert(QStringLiteral("use-color"), useColor);
+            }
+
+            g_autofree gchar *duplex = nullptr;
+            if (g_variant_lookup(settings, "duplex", "s", &duplex)) {
+                settingsMap.insert(QStringLiteral("duplex"), duplex);
+            }
+
+            g_autofree gchar *collate = nullptr;
+            if (g_variant_lookup(settings, "collate", "s", &collate)) {
+                settingsMap.insert(QStringLiteral("collate"), collate);
+            }
+
+            g_autofree gchar *reverse = nullptr;
+            if (g_variant_lookup(settings, "reverse", "s", &reverse)) {
+                settingsMap.insert(QStringLiteral("reverse"), reverse);
+            }
+
+            g_autofree gchar *range = nullptr;
+            if (g_variant_lookup(settings, "print-pages", "s", &range)) {
+                settingsMap.insert(QStringLiteral("print-pages"), range);
+            }
+
+            g_autofree gchar *pageRanges = nullptr;
+            if (g_variant_lookup(settings, "page-ranges", "s", &pageRanges)) {
+                settingsMap.insert(QStringLiteral("page-ranges"), pageRanges);
+            }
+
+            g_autofree gchar *outputFileFormat = nullptr;
+            if (g_variant_lookup(settings, "output-file-format", "s", &outputFileFormat)) {
+                settingsMap.insert(QStringLiteral("output-file-format"), outputFileFormat);
+            }
+
+            g_autofree gchar *baseName = nullptr;
+            if (g_variant_lookup(settings, "output-basename", "s", &baseName)) {
+                settingsMap.insert(QStringLiteral("output-basename"), baseName);
+            }
+
+            g_autofree gchar *outputUri = nullptr;
+            if (g_variant_lookup(settings, "output-uri", "s", &outputUri)) {
+                settingsMap.insert(QStringLiteral("output-uri"), outputUri);
+            }
+        }
+
+        pageSetup = g_variant_lookup_value(ret, "page-setup", G_VARIANT_TYPE_DICTIONARY);
+
+        if (pageSetup) {
+            g_autofree gchar *ppdName = nullptr;
+            if (g_variant_lookup(pageSetup, "PPDName", "s", &ppdName)) {
+                pageSetupMap.insert(QStringLiteral("PPDName"), ppdName);
+            }
+
+            g_autofree gchar *name = nullptr;
+            if (g_variant_lookup(pageSetup, "Name", "s", &name)) {
+                pageSetupMap.insert(QStringLiteral("Name"), name);
+            }
+
+            g_autofree gchar *displayName = nullptr;
+            if (g_variant_lookup(pageSetup, "DisplayName", "s", &displayName)) {
+                pageSetupMap.insert(QStringLiteral("DisplayName"), displayName);
+            }
+
+            gdouble width = 0;
+            if (g_variant_lookup(pageSetup, "Width", "d", &width)) {
+                pageSetupMap.insert(QStringLiteral("Width"), width);
+            }
+
+            gdouble height = 0;
+            if (g_variant_lookup(pageSetup, "Height", "d", &height)) {
+                pageSetupMap.insert(QStringLiteral("Height"), height);
+            }
+
+            gdouble marginTop = 0;
+            gdouble marginBottom = 0;
+            gdouble marginLeft = 0;
+            gdouble marginRight = 0;
+            if (g_variant_lookup(pageSetup, "MarginTop", "d", &marginTop)) {
+                pageSetupMap.insert(QStringLiteral("MarginTop"), marginTop);
+            }
+
+            if (g_variant_lookup(pageSetup, "MarginBottom", "d", &marginBottom)) {
+                pageSetupMap.insert(QStringLiteral("MarginBottom"), marginBottom);
+            }
+
+            if (g_variant_lookup(pageSetup, "MarginLeft", "d", &marginLeft)) {
+                pageSetupMap.insert(QStringLiteral("MarginLeft"), marginLeft);
+            }
+
+            if (g_variant_lookup(pageSetup, "MarginRight", "d", &marginRight)) {
+                pageSetupMap.insert(QStringLiteral("MarginRight"), marginRight);
+            }
+
+            g_autofree gchar *orientation = nullptr;
+            if (g_variant_lookup(settings, "Orientation", "s", &orientation)) {
+                pageSetupMap.insert(QStringLiteral("Orientation"), orientation);
+            }
+        }
+
+        g_variant_lookup(ret, "token", "u", &token);
+
+        responseData.insert(QStringLiteral("settings"), settingsMap);
+        responseData.insert(QStringLiteral("page-setup"), pageSetupMap);
+        responseData.insert(QStringLiteral("token"), token);
+        Response response(true, error, responseData);
+        portalPrivate->preparePrintResponse(response);
+    } else {
+        Response response(false, error);
+        portalPrivate->preparePrintResponse(response);
+    }
+}
+
+void PortalPrivate::printFile(const Parent &parent, const QString &title, int token, const QString &file, PrintFlags flags)
+{
+    xdp_portal_print_file(m_xdpPortal, parent.d_ptr->m_xdpParent, title.toUtf8().constData(), token, file.toUtf8().constData(),
+                          static_cast<XdpPrintFlags>((int)flags), nullptr, printedFile, this);
+}
+
+void PortalPrivate::printedFile(GObject *object, GAsyncResult *result, gpointer data)
+{
+    XdpPortal *xdpPortal = XDP_PORTAL(object);
+    PortalPrivate *portalPrivate = static_cast<PortalPrivate*>(data);
+    g_autoptr(GError) error = nullptr;
+
+    bool ret = xdp_portal_print_file_finish(xdpPortal, result, &error);
+
+    Response response(ret, error);
+
+    portalPrivate->printFileResponse(response);
+}
+
+}

--- a/libportal-qt/print.h
+++ b/libportal-qt/print.h
@@ -17,32 +17,24 @@
  * SPDX-License-Identifier: LGPL-3.0-only
  */
 
-#ifndef PORTAL_TEST_QT_H
-#define PORTAL_TEST_QT_H
+#ifndef LIBPORTALQT_PRINT_H
+#define LIBPORTALQT_PRINT_H
 
-#include <QMainWindow>
-#include "portal.h"
+#include <QFlags>
 
-class Ui_PortalTestQt;
-
-class PortalTestQt : public QMainWindow
+namespace Xdp
 {
-    Q_OBJECT
-public:
-    PortalTestQt(QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
-    ~PortalTestQt();
 
-    void updateLastOpenedFile(const QString &file);
-private Q_SLOTS:
-    void onUserInformationReceived(const Xdp::Response &response);
-    void onFileOpened(const Xdp::Response &response);
-    void onSessionInhibited(const Xdp::Response &response);
-
-private:
-    Ui_PortalTestQt *m_mainWindow;
-    int m_inhibitorId = -1;
-    QString m_fileToPrint;
-    int m_printToken;
+enum class PrintFlag
+{
+    None = 0x0
 };
+Q_DECLARE_FLAGS(PrintFlags, PrintFlag)
+}
+Q_DECLARE_OPERATORS_FOR_FLAGS(Xdp::PrintFlags)
 
-#endif // PORTAL_TEST_QT_H
+#endif // LIBPORTALQT_PRINT_H
+
+
+
+

--- a/libportal-qt/response.cpp
+++ b/libportal-qt/response.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2020-2021, Jan Grulich
+ *
+ * This file is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, version 3.0 of the
+ * License.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-only
+ */
+
+#include "response.h"
+
+namespace Xdp
+{
+
+class ResponsePrivate : public QObject {
+public:
+    ResponsePrivate(bool success, const GError *error, const QVariantMap &result = QVariantMap(), QObject *parent = nullptr);
+    ~ResponsePrivate();
+
+    bool m_success = false;
+    QString m_errorMessage;
+    QVariantMap m_result;
+};
+
+ResponsePrivate::ResponsePrivate(bool success, const GError *error, const QVariantMap &result, QObject *parent)
+    : QObject(parent)
+    , m_success(success)
+    , m_result(result)
+{
+    if (error) {
+        m_errorMessage = QString::fromUtf8(error->message);
+    }
+}
+
+ResponsePrivate::~ResponsePrivate()
+{
+}
+
+Response::Response(bool success, const GError *error, const QVariantMap &result, QObject *parent)
+    : d_ptr(new ResponsePrivate(success, error, result, parent))
+{
+}
+
+Response::~Response()
+{
+}
+
+bool Response::isError() const
+{
+    Q_D(const Response);
+    return !d->m_success;
+}
+
+bool Response::isSuccess() const
+{
+    Q_D(const Response);
+    return d->m_success;
+}
+
+QString Response::errorMessage() const
+{
+    Q_D(const Response);
+    return d->m_errorMessage;
+}
+
+QVariantMap Response::result() const
+{
+    Q_D(const Response);
+    return d->m_result;
+}
+
+}

--- a/libportal-qt/response.h
+++ b/libportal-qt/response.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2020-2021, Jan Grulich
+ *
+ * This file is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, version 3.0 of the
+ * License.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-only
+ */
+
+#ifndef LIBPORTALQT_RESPONSE_H
+#define LIBPORTALQT_RESPONSE_H
+
+#undef signals
+#include <gio/gio.h>
+#define signals Q_SIGNALS
+
+#include <QVariantMap>
+
+#include "libportalqt_export.h"
+
+namespace Xdp
+{
+
+class ResponsePrivate;
+
+class LIBPORTALQT_EXPORT Response : public QObject
+{
+Q_OBJECT
+public:
+    Q_PROPERTY(bool isError READ isError)
+    Q_PROPERTY(bool isSuccess READ isSuccess)
+    Q_PROPERTY(QString errorMessage READ errorMessage)
+    Q_PROPERTY(QVariantMap result READ result)
+
+    explicit Response(bool success, const GError *error, const QVariantMap &result = QVariantMap(), QObject *parent = nullptr);
+    virtual ~Response();
+
+    bool isError() const;
+
+    bool isSuccess() const;
+
+    QString errorMessage() const;
+
+    QVariantMap result() const;
+
+private:
+    Q_DECLARE_PRIVATE(Response)
+
+    const QScopedPointer<ResponsePrivate> d_ptr;
+};
+} // namespace Xdp
+
+#endif // LIBPORTALQT_RESPONSE_H
+

--- a/libportal/meson.build
+++ b/libportal/meson.build
@@ -154,7 +154,7 @@ endif
 if 'qt5' in backends
   add_languages('cpp', required : true)
 
-  qt5_dep = dependency('qt5', modules: ['Core', 'Gui', 'X11Extras', 'Widgets'])
+  qt5_dep = dependency('qt5', modules: ['Core', 'Gui', 'Widgets'])
   qt5_headers = ['portal-qt5.h']
   qt5_sources = files('portal-qt5.cpp')
 

--- a/libportal/portal-qt5.cpp
+++ b/libportal/portal-qt5.cpp
@@ -23,14 +23,14 @@
 
 #include "parent-private.h"
 
-#include <QX11Info>
+#include <QApplication>
 
 static gboolean
 _xdp_parent_export_qt (XdpParent *parent,
                        XdpParentExported callback,
                        gpointer data)
 {
-  if (QX11Info::isPlatformX11 ())
+  if (QGuiApplication::platformName () == QStringLiteral("xcb"))
     {
       QWindow *w = (QWindow *) parent->data;
       if (w) {

--- a/meson.build
+++ b/meson.build
@@ -28,8 +28,17 @@ libportal_inc = include_directories('libportal')
 
 subdir('libportal')
 
+if get_option('qt5')
+  libportalqt_inc = include_directories('libportal-qt')
+  subdir('libportal-qt')
+endif
+
 if get_option('portal-tests')
   subdir('portal-test')
+endif
+
+if get_option('tests')
+  subdir('tests')
 endif
 
 if get_option('gtk_doc')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,5 +2,9 @@ option('backends', type: 'array', choices: ['gtk3', 'gtk4', 'qt5'], value: ['gtk
   description : 'A list of portal backends to build')
 option('portal-tests', type: 'boolean', value: false,
   description : 'Build portal tests of each backend')
+option('tests', type: 'boolean', value: false,
+  description : 'Build portal unit tests')
+option('qt5', type: 'boolean', value: true,
+  description : 'Build the Qt bindings')
 option('gtk_doc', type: 'boolean', value: true,
   description : 'Build API reference with gtk-doc')

--- a/portal-test/qt5/main.cpp
+++ b/portal-test/qt5/main.cpp
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2020-2021, Jan Grulich
+ *
+ * This file is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, version 3.0 of the
+ * License.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-only
+ */
 
 #include <QApplication>
 

--- a/portal-test/qt5/meson.build
+++ b/portal-test/qt5/meson.build
@@ -1,6 +1,8 @@
 
 add_languages('cpp', required : true)
 
+qt_dep = dependency('qt5', modules: ['Core', 'Gui', 'Widgets'])
+
 src = [
   'main.cpp',
   'portal-test-qt.h',
@@ -17,7 +19,8 @@ prep = qt.preprocess(
 executable('portal-test-qt',
   [src, prep],
   include_directories: [top_inc, libportal_inc],
-  dependencies: [libportal_qt5_dep],
+  dependencies: [libportal_qt5_dep, libportalqt_dep],
+  link_with: [libportalqt],
   cpp_args : '-std=c++11',
   install : true,
 )

--- a/portal-test/qt5/portal-test-qt.ui
+++ b/portal-test/qt5/portal-test-qt.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>355</width>
-    <height>100</height>
+    <width>948</width>
+    <height>450</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,17 +16,291 @@
   <widget class="QWidget" name="centralwidget">
    <layout class="QGridLayout" name="gridLayout">
     <item row="0" column="0">
-     <widget class="QPushButton" name="openFileButton">
+     <widget class="QGroupBox" name="groupBox_3">
+      <property name="title">
+       <string>Account portal</string>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <widget class="QPushButton" name="getUserInformationButton">
+         <property name="focusPolicy">
+          <enum>Qt::NoFocus</enum>
+         </property>
+         <property name="text">
+          <string>Get user information...</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item row="0" column="1">
+     <widget class="QGroupBox" name="groupBox_4">
+      <property name="title">
+       <string>Background portal</string>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_4">
+       <item>
+        <widget class="QPushButton" name="requestBackgroundButton">
+         <property name="focusPolicy">
+          <enum>Qt::NoFocus</enum>
+         </property>
+         <property name="text">
+          <string>Request background</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item row="0" column="2">
+     <widget class="QGroupBox" name="groupBox_8">
+      <property name="title">
+       <string>Location portal</string>
+      </property>
+      <layout class="QGridLayout" name="gridLayout_3">
+       <item row="0" column="0">
+        <widget class="QPushButton" name="startLocationMonitorButton">
+         <property name="text">
+          <string>Start monitor</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QPushButton" name="stopLocationMonitorButton">
+         <property name="text">
+          <string>Stop monitor</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item row="1" column="0" rowspan="3">
+     <widget class="QGroupBox" name="groupBox">
+      <property name="title">
+       <string>FileChooser portal</string>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <widget class="QPushButton" name="openFileButton">
+         <property name="focusPolicy">
+          <enum>Qt::NoFocus</enum>
+         </property>
+         <property name="text">
+          <string>Open File...</string>
+         </property>
+         <property name="autoDefault">
+          <bool>false</bool>
+         </property>
+         <property name="default">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="saveFileButton">
+         <property name="focusPolicy">
+          <enum>Qt::NoFocus</enum>
+         </property>
+         <property name="text">
+          <string>Save file</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="saveFilesButton">
+         <property name="focusPolicy">
+          <enum>Qt::NoFocus</enum>
+         </property>
+         <property name="text">
+          <string>Save files</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item row="1" column="1">
+     <widget class="QGroupBox" name="groupBox_5">
+      <property name="title">
+       <string>Camera portal</string>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_6">
+       <item>
+        <widget class="QPushButton" name="accessCameraButton">
+         <property name="focusPolicy">
+          <enum>Qt::NoFocus</enum>
+         </property>
+         <property name="text">
+          <string>Access Camera</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item row="1" column="2" rowspan="2">
+     <widget class="QGroupBox" name="groupBox_9">
+      <property name="title">
+       <string>Notification portal</string>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_7">
+       <item>
+        <widget class="QPushButton" name="addNotificationButton">
+         <property name="text">
+          <string>Add notification</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="removeNotificationButton">
+         <property name="text">
+          <string>Remove Notification</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item row="2" column="1" rowspan="2">
+     <widget class="QGroupBox" name="groupBox_6">
+      <property name="title">
+       <string>Email portal</string>
+      </property>
+      <layout class="QGridLayout" name="gridLayout_2">
+       <item row="0" column="0">
+        <widget class="QPushButton" name="composeEmailButton">
+         <property name="text">
+          <string>Compose email</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item row="4" column="0">
+     <widget class="QGroupBox" name="groupBox_2">
+      <property name="title">
+       <string>OpenURI portal</string>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QPushButton" name="openLinkButton">
+         <property name="focusPolicy">
+          <enum>Qt::NoFocus</enum>
+         </property>
+         <property name="text">
+          <string>Open link...</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="openDirectoryButton">
+         <property name="focusPolicy">
+          <enum>Qt::NoFocus</enum>
+         </property>
+         <property name="text">
+          <string>Open directory...</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item row="4" column="1">
+     <widget class="QGroupBox" name="groupBox_7">
+      <property name="title">
+       <string>Inhibit portal</string>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_5">
+       <item>
+        <widget class="QPushButton" name="inhibitButton">
+         <property name="text">
+          <string>Inhibit</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="uninhibitButton">
+         <property name="text">
+          <string>Uninhibit</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item row="5" column="0">
+     <spacer name="verticalSpacer">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>20</width>
+        <height>157</height>
+       </size>
+      </property>
+     </spacer>
+    </item>
+    <item row="6" column="0" colspan="3">
+     <widget class="QLabel" name="label">
       <property name="text">
-       <string>Open File...</string>
+       <string>Some actions don't have any visible effect and can be only verified when using dbus-monitor.</string>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
       </property>
      </widget>
     </item>
-    <item row="1" column="0">
-     <widget class="QLabel" name="openedFileLabel">
-      <property name="text">
-       <string>No file opened!!</string>
+    <item row="5" column="2">
+     <spacer name="verticalSpacer_2">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
       </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>20</width>
+        <height>40</height>
+       </size>
+      </property>
+     </spacer>
+    </item>
+    <item row="3" column="2" rowspan="2">
+     <widget class="QGroupBox" name="groupBox_10">
+      <property name="title">
+       <string>Print portal</string>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_8">
+       <item>
+        <widget class="QPushButton" name="preparePrintButton">
+         <property name="text">
+          <string>Prepare print</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="printFileButton">
+         <property name="text">
+          <string>Print file</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>31</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
      </widget>
     </item>
    </layout>

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,3 @@
+if get_option('qt5')
+  subdir('qt5')
+endif

--- a/tests/qt5/meson.build
+++ b/tests/qt5/meson.build
@@ -1,0 +1,21 @@
+
+add_languages('cpp', required : true)
+
+qt_dep = dependency('qt5', modules: ['Core', 'Test'])
+
+src = ['qttest.cpp',
+       'qttest.h']
+
+prep = qt.preprocess(moc_headers : 'qttest.h',
+                     moc_extra_arguments: ['-DMAKES_MY_MOC_HEADER_COMPILE'],
+                     dependencies: qt_dep)
+
+exe = executable('qt-test',
+                 [src, prep],
+                 include_directories: [top_inc, libportalqt_inc],
+                 dependencies: [qt_dep, libportalqt_dep],
+                 link_with: [libportalqt],
+                 cpp_args : '-std=c++11')
+
+test('Qt unit test', exe)
+

--- a/tests/qt5/qttest.cpp
+++ b/tests/qt5/qttest.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2021, Jan Grulich
+ *
+ * This file is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, version 3.0 of the
+ * License.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-only
+ */
+
+#include "portal_p.h"
+#include "portal.h"
+#include "qttest.h"
+
+#include <QSignalSpy>
+#include <QTest>
+
+void QtTest::testFileChooserPortal()
+{
+    Xdp::FileChooserFilterRule rule(Xdp::FileChooserFilterRule::Type::Mimetype, QStringLiteral("image/jpeg"));
+    Xdp::FileChooserFilter filter(QStringLiteral("Images"), {rule});
+
+    g_autoptr(GVariant) filterVar = Xdp::PortalPrivate::filterToVariant(filter);
+    const QString expectedFilterVarStr = "('Images', [(1, 'image/jpeg')])";
+    const QString filterVarStr = g_variant_print(filterVar, false);
+    QCOMPARE(expectedFilterVarStr, filterVarStr);
+
+
+    Xdp::FileChooserFilterRule rule2;
+    rule2.setType(Xdp::FileChooserFilterRule::Type::Pattern);
+    rule2.setRule(QStringLiteral("*.png"));
+    filter.addRule(rule2);
+
+    g_autoptr(GVariant) filterVar2 = Xdp::PortalPrivate::filterToVariant(filter);
+    const QString expectedFilterVarStr2 = "('Images', [(1, 'image/jpeg'), (0, '*.png')])";
+    const QString filterVarStr2 = g_variant_print(filterVar2, false);
+    QCOMPARE(expectedFilterVarStr2, filterVarStr2);
+
+    Xdp::FileChooserFilterList filterList;
+    filterList << filter << filter;
+
+    g_autoptr(GVariant) filterListVar = Xdp::PortalPrivate::filterListToVariant(filterList);
+    const QString expectedFilterListVarStr = "[('Images', [(1, 'image/jpeg'), (0, '*.png')]), ('Images', [(1, 'image/jpeg'), (0, '*.png')])]";
+    const QString filterListVarStr = g_variant_print(filterListVar, false);
+    QCOMPARE(expectedFilterListVarStr, filterListVarStr);
+
+    Xdp::FileChooserChoice choice(QStringLiteral("choice-id"), QStringLiteral("choice-label"),
+                                  QMap<QString, QString>{{QStringLiteral("option1-id"), QStringLiteral("option1-value")}}, QStringLiteral("option1-id"));
+    choice.addOption(QStringLiteral("option2-id"), QStringLiteral("option2-value"));
+
+    g_autoptr(GVariant) choiceVar = Xdp::PortalPrivate::choiceToVariant(choice);
+    const QString expectedChoiceVarStr = "('choice-id', 'choice-label', [('option1-id', 'option1-value'), ('option2-id', 'option2-value')], 'option1-id')";
+    const QString choiceVarStr = g_variant_print(choiceVar, false);
+    QCOMPARE(expectedChoiceVarStr, choiceVarStr);
+}
+
+void QtTest::testNotificationPortal()
+{
+    Xdp::NotificationButton button(QStringLiteral("Some label"), QStringLiteral("Some action"));
+
+    g_autoptr(GVariant) buttonsVar = Xdp::PortalPrivate::buttonsToVariant({button});
+    const QString expectedButtonsVarStr = "[{'label': <'Some label'>, 'action': <'Some action'>}]";
+    const QString buttonsVarStr = g_variant_print(buttonsVar, false);
+    QCOMPARE(expectedButtonsVarStr, buttonsVarStr);
+
+    Xdp::Notification notification(QStringLiteral("Test notification"), QStringLiteral("Testing notification portal"));
+    notification.setIcon(QStringLiteral("applications-development"));
+    notification.addButton(button);
+
+    g_autoptr(GVariant) notificationVar = Xdp::PortalPrivate::notificationToVariant(notification);
+    const QString expectedNotificationVarStr = "{'title': <'Test notification'>, 'body': <'Testing notification portal'>, 'icon': <('themed', <['applications-development', 'applications-development-symbolic']>)>, 'buttons': <[{'label': <'Some label'>, 'action': <'Some action'>}]>}";
+    const QString notificationStr = g_variant_print(notificationVar, false);
+    QCOMPARE(expectedNotificationVarStr, notificationStr);
+}
+
+
+QTEST_MAIN(QtTest)

--- a/tests/qt5/qttest.h
+++ b/tests/qt5/qttest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021, Jan Grulich
+ * Copyright (C) 2021, Jan Grulich
  *
  * This file is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as
@@ -17,32 +17,17 @@
  * SPDX-License-Identifier: LGPL-3.0-only
  */
 
-#ifndef PORTAL_TEST_QT_H
-#define PORTAL_TEST_QT_H
+#ifndef QT_TEST_H
+#define QT_TEST_H
 
-#include <QMainWindow>
-#include "portal.h"
+#include <QObject>
 
-class Ui_PortalTestQt;
-
-class PortalTestQt : public QMainWindow
+class QtTest : public QObject
 {
     Q_OBJECT
-public:
-    PortalTestQt(QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
-    ~PortalTestQt();
-
-    void updateLastOpenedFile(const QString &file);
 private Q_SLOTS:
-    void onUserInformationReceived(const Xdp::Response &response);
-    void onFileOpened(const Xdp::Response &response);
-    void onSessionInhibited(const Xdp::Response &response);
-
-private:
-    Ui_PortalTestQt *m_mainWindow;
-    int m_inhibitorId = -1;
-    QString m_fileToPrint;
-    int m_printToken;
+    void testFileChooserPortal();
+    void testNotificationPortal();
 };
 
-#endif // PORTAL_TEST_QT_H
+#endif // QT_TEST_H


### PR DESCRIPTION
Libportal-qt is a Qt wrapper for libportal. It uses very similar API, it's just more qute (Qt friendly).

### Qt wrappers
- [x] Account portal
- [x] Background portal
- [x] Camera portal
- [x] Email portal
- [x] FileChooser portal
- [x] Inhibit portal
- [x] Location portal
- [x] Notification portal
- [x] OpenUri portal
- [x] Print portal

### How does the API look like?
GLib
```
static void
opened_uri (GObject *object,
            GAsyncResult *result,
            gpointer data)
{
  /* Implementation of opened_uri response */
}

XdpOpenUriFlags flags = XDP_OPEN_URI_FLAG_NONE;
XdpParent *parent = xdp_parent_new_gtk (GTK_WINDOW (win));
xdp_portal_open_uri (win->portal, parent, "https://github.com/flatpak/libportal", flags, NULL, opened_uri, win);
```
Qt
```
Xdp::Parent xdpParent(windowHandle());
Xdp::openUri(xdpParent, QStringLiteral("https://github.com/flatpak/libportal"), Xdp::OpenUriFlag::None);
connect(Xdp::notifier(), &Xdp::Notifier::openUriResponse, this, [=] (const Xdp::Response &response) {
     if (response.isSuccess()) { // DO SOMETHING }
});
```

### Other benefits
This Qt wrapper also makes it more convenient to use, because the GLib implementation takes some arguments as GVariants and forces everyone to look into the documentation for all possible values they can pass there, while I wrote convenient classes with getters/setters for each option.

E.g. in the FileChooser portal:
**GLib**: `xdg_portal_open_file()` takes filters as `GVariant`
**Qt**: `Xdp::openFile()` takes `FileChooserFilter` class as an argument with getters/setters to set `id`, `label` and `rule`.