### PR TITLE
Flatpak & CI improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,10 @@ jobs:
           sudo add-apt-repository ppa:alexlarsson/glib260
           sudo add-apt-repository 'deb https://download.mono-project.com/repo/ubuntu stable-bionic main' # Needed for updates to work
           sudo apt-get update
-          sudo apt-get install -y libglib2.0 gettext dbus gtk-doc-tools meson libgirepository1.0-dev
+          sudo apt-get install -y libglib2.0 gettext dbus gtk-doc-tools meson libgirepository1.0-dev libgtk-3-dev
       - name: Check out libportal
         uses: actions/checkout@v1
       - name: Configure libportal
-        run: meson setup --prefix=/usr _build -Dbackends=
+        run: meson setup --prefix=/usr _build -Dbackends=gtk3
       - name: Build libportal
         run: ninja -C_build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,3 +62,19 @@ jobs:
         run: meson setup --prefix=/usr _build -Dbackends=gtk3,gtk4
       - name: Build libportal
         run: ninja -C_build
+
+  fedora-35:
+    name: Fedora 35
+    runs-on: ubuntu-latest
+    container: fedora:35
+
+    steps:
+      - name: Install dependencies
+        run: |
+          dnf install -y meson gcc gtk-doc gobject-introspection-devel gtk3-devel gtk4-devel
+      - name: Check out libportal
+        uses: actions/checkout@v1
+      - name: Configure libportal
+        run: meson setup --prefix=/usr _build -Dbackends=gtk3,gtk4
+      - name: Build libportal
+        run: ninja -C_build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,20 +12,20 @@ on:
     - master
 
 jobs:
-  build:
-
+  ubuntu-18-04:
+    name: Ubuntu 18.04
     runs-on: ubuntu-18.04
-    
+
     steps:
-    - name: Install dependencies
-      run: |
-        sudo add-apt-repository ppa:alexlarsson/glib260
-        sudo add-apt-repository 'deb https://download.mono-project.com/repo/ubuntu stable-bionic main' # Needed for updates to work
-        sudo apt-get update
-        sudo apt-get install -y libglib2.0 gettext dbus gtk-doc-tools meson libgirepository1.0-dev
-    - name: Check out libportal
-      uses: actions/checkout@v1
-    - name: Configure libportal
-      run: meson setup --prefix=/usr _build -Dbackends=
-    - name: Build libportal
-      run: ninja -C_build
+      - name: Install dependencies
+        run: |
+          sudo add-apt-repository ppa:alexlarsson/glib260
+          sudo add-apt-repository 'deb https://download.mono-project.com/repo/ubuntu stable-bionic main' # Needed for updates to work
+          sudo apt-get update
+          sudo apt-get install -y libglib2.0 gettext dbus gtk-doc-tools meson libgirepository1.0-dev
+      - name: Check out libportal
+        uses: actions/checkout@v1
+      - name: Configure libportal
+        run: meson setup --prefix=/usr _build -Dbackends=
+      - name: Build libportal
+        run: ninja -C_build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,3 +45,20 @@ jobs:
         run: meson setup --prefix=/usr _build -Dbackends=gtk3
       - name: Build libportal
         run: ninja -C_build
+
+  ubuntu-21-04:
+    name: Ubuntu 21.10
+    runs-on: ubuntu-latest
+    container: ubuntu:21.10
+
+    steps:
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y libglib2.0 gettext dbus gtk-doc-tools meson libgirepository1.0-dev libgtk-3-dev libgtk-4-dev
+      - name: Check out libportal
+        uses: actions/checkout@v1
+      - name: Configure libportal
+        run: meson setup --prefix=/usr _build -Dbackends=gtk3,gtk4
+      - name: Build libportal
+        run: ninja -C_build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,3 +29,19 @@ jobs:
         run: meson setup --prefix=/usr _build -Dbackends=gtk3
       - name: Build libportal
         run: ninja -C_build
+
+  ubuntu-20-04:
+    name: Ubuntu 20.04
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libglib2.0 gettext dbus gtk-doc-tools meson libgirepository1.0-dev libgtk-3-dev
+      - name: Check out libportal
+        uses: actions/checkout@v1
+      - name: Configure libportal
+        run: meson setup --prefix=/usr _build -Dbackends=gtk3
+      - name: Build libportal
+        run: ninja -C_build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: libportal CI
 
+env:
+  DEBIAN_FRONTEND: noninteractive
+
 on:
   push:
     branches:

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -1,0 +1,63 @@
+---
+
+name: PortalTest Flatpak
+
+on:
+  push:
+    paths-ignore: ['**.md']
+    branches: [master]
+  pull_request:
+    paths-ignore: ['**.md']
+    branches: [master]
+
+jobs:
+  build-flatpak-gtk3:
+    name: GTK3
+    runs-on: ubuntu-latest
+    container:
+      image: bilelmoussaoui/flatpak-github-actions:gnome-41
+      options: --privileged
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build GTK3 portal test
+        uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v3
+        with:
+          bundle: portal-test-gtk3.flatpak
+          manifest-path: build-aux/org.gnome.PortalTest.Gtk3.json
+          cache-key: gtk3-${{ github.sha }}
+
+  build-flatpak-gtk4:
+    name: GTK4
+    runs-on: ubuntu-latest
+    container:
+      image: bilelmoussaoui/flatpak-github-actions:gnome-41
+      options: --privileged
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build GTK4 portal test
+        uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v3
+        with:
+          bundle: portal-test-gtk4.flatpak
+          manifest-path: build-aux/org.gnome.PortalTest.Gtk4.json
+          cache-key: gtk4-${{ github.sha }}
+
+  build-flatpak-qt5:
+    name: Qt5
+    runs-on: ubuntu-latest
+    container:
+      image: bilelmoussaoui/flatpak-github-actions:kde-5.15
+      options: --privileged
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build Qt5 portal test
+        uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v3
+        with:
+          bundle: portal-test-qt.flatpak
+          manifest-path: build-aux/org.gnome.PortalTest.Qt5.json
+          cache-key: qt-${{ github.sha }}

--- a/build-aux/org.gnome.PortalTest.Gtk3.json
+++ b/build-aux/org.gnome.PortalTest.Gtk3.json
@@ -37,8 +37,8 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/flatpak/libportal"
+                    "type": "dir",
+                    "path": "../"
                 }
             ]
         }

--- a/build-aux/org.gnome.PortalTest.Gtk4.json
+++ b/build-aux/org.gnome.PortalTest.Gtk4.json
@@ -22,8 +22,8 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/flatpak/libportal"
+                    "type": "dir",
+                    "path": "../"
                 }
             ]
         }

--- a/build-aux/org.gnome.PortalTest.Qt5.json
+++ b/build-aux/org.gnome.PortalTest.Qt5.json
@@ -21,8 +21,8 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/flatpak/libportal"
+                    "type": "dir",
+                    "path": "../"
                 }
             ]
         }


### PR DESCRIPTION
Generate Flatpak bundles for all manifests we have in-tree.

Cleanup and increment the builds to include:

 * Ubuntu 20.04
 * Ubuntu 21.10
 * Fedora 35