### PR TITLE
build-aux/build.sh: Build all manual tests as Flatpak apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.flatpak-builder/
+/_build/

--- a/build-aux/build.sh
+++ b/build-aux/build.sh
@@ -6,13 +6,9 @@ TOP_DIR=`dirname $0`/..
 OLD_DIR=`pwd`
 
 cd "$TOP_DIR"
-JSON=build-aux/org.gnome.PortalTest.Gtk3.json
-# Keep in sync with manifest
-MESON_ARGS="-Dportal-tests=gtk3 -Dgtk_doc=false"
 
-rm -rf _flatpak_meson_build
-flatpak-builder --force-clean --ccache --repo=repo --install --user --stop-at=portal-test-gtk3 app $JSON
-flatpak build app meson --prefix=/app --libdir=lib $MESON_ARGS _flatpak_meson_build
-flatpak build app ninja -C _flatpak_meson_build install
-flatpak-builder --finish-only --repo=repo app $JSON
+for backend in Gtk3 Gtk4 Qt5; do
+    flatpak-builder --force-clean --ccache --repo=_build/repo --install --user "_build/app-$backend" "build-aux/org.gnome.PortalTest.${backend}.json"
+done
+
 cd "$OLD_DIR"


### PR DESCRIPTION
Previously this convenience script only built the Gtk3 version.