### PR TITLE
Screencast session restore

### DIFF
--- a/libportal/portal-private.h
+++ b/libportal/portal-private.h
@@ -48,6 +48,9 @@ struct _XdpPortal {
 
   /* notification */
   guint action_invoked_signal;
+
+  /* screencast */
+  guint screencast_interface_version;
 };
 
 #define PORTAL_BUS_NAME "org.freedesktop.portal.Desktop"

--- a/libportal/remote.c
+++ b/libportal/remote.c
@@ -722,7 +722,7 @@ xdp_session_close (XdpSession *session)
  * a pw_remote object, by using pw_remote_connect_fd(). Only the
  * screencast stream nodes will be available from this pipewire node.
  *
- * Returns: the file ddescriptor
+ * Returns: the file descriptor
  */
 int
 xdp_session_open_pipewire_remote (XdpSession *session)

--- a/libportal/remote.c
+++ b/libportal/remote.c
@@ -53,6 +53,8 @@ typedef struct {
   XdpDeviceType devices;
   XdpOutputType outputs;
   XdpCursorMode cursor_mode;
+  XdpPersistMode persist_mode;
+  char *restore_token;
   gboolean multiple;
   guint signal_id;
   GTask *task;
@@ -70,6 +72,7 @@ create_call_free (CreateCall *call)
     g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
 
   g_free (call->request_path);
+  g_free (call->restore_token);
 
   g_object_unref (call->portal);
   g_object_unref (call->task);
@@ -151,6 +154,12 @@ select_sources (CreateCall *call)
   g_variant_builder_add (&options, "{sv}", "types", g_variant_new_uint32 (call->outputs));
   g_variant_builder_add (&options, "{sv}", "multiple", g_variant_new_boolean (call->multiple));
   g_variant_builder_add (&options, "{sv}", "cursor_mode", g_variant_new_uint32 (call->cursor_mode));
+  if (call->portal->screencast_interface_version >= 4)
+    {
+      g_variant_builder_add (&options, "{sv}", "persist_mode", g_variant_new_uint32 (call->persist_mode));
+      if (call->restore_token)
+        g_variant_builder_add (&options, "{sv}", "restore_token", g_variant_new_string (call->restore_token));
+    }
   g_dbus_connection_call (call->portal->bus,
                           PORTAL_BUS_NAME,
                           PORTAL_OBJECT_PATH,
@@ -385,6 +394,8 @@ get_screencast_interface_version (CreateCall *call)
  * @outputs: which kinds of source to offer in the dialog
  * @flags: options for this call
  * @cursor_mode: the cursor mode of the session
+ * @persist_mode: the persist mode of the session
+ * @restore_token: (nullable): the token of a previous screencast session to restore
  * @cancellable: (nullable): optional #GCancellable
  * @callback: (scope async): a callback to call when the request is done
  * @data: (closure): data to pass to @callback
@@ -399,6 +410,8 @@ xdp_portal_create_screencast_session (XdpPortal *portal,
                                       XdpOutputType outputs,
                                       XdpScreencastFlags flags,
                                       XdpCursorMode cursor_mode,
+                                      XdpPersistMode persist_mode,
+                                      const char *restore_token,
                                       GCancellable *cancellable,
                                       GAsyncReadyCallback  callback,
                                       gpointer data)
@@ -414,6 +427,8 @@ xdp_portal_create_screencast_session (XdpPortal *portal,
   call->devices = XDP_DEVICE_NONE;
   call->outputs = outputs;
   call->cursor_mode = cursor_mode;
+  call->persist_mode = persist_mode;
+  call->restore_token = g_strdup (restore_token);
   call->multiple = (flags & XDP_SCREENCAST_FLAG_MULTIPLE) != 0;
   call->task = g_task_new (portal, cancellable, callback, data);
 
@@ -487,6 +502,8 @@ xdp_portal_create_remote_desktop_session (XdpPortal *portal,
   call->devices = devices;
   call->outputs = outputs;
   call->cursor_mode = cursor_mode;
+  call->persist_mode = XDP_PERSIST_MODE_NONE;
+  call->restore_token = NULL;
   call->multiple = (flags & XDP_REMOTE_DESKTOP_FLAG_MULTIPLE) != 0;
   call->task = g_task_new (portal, cancellable, callback, data);
 
@@ -581,6 +598,10 @@ session_started (GDBusConnection *bus,
       guint32 devices;
       GVariant *streams;
 
+      if (!g_variant_lookup (ret, "persist_mode", "u", &call->session->persist_mode))
+        call->session->persist_mode = XDP_PERSIST_MODE_NONE;
+      if (!g_variant_lookup (ret, "restore_token", "s", &call->session->restore_token))
+        call->session->restore_token = NULL;
       if (g_variant_lookup (ret, "devices", "u", &devices))
         _xdp_session_set_devices (call->session, devices);
       if (g_variant_lookup (ret, "streams", "@a(ua{sv})", &streams))
@@ -1119,4 +1140,50 @@ xdp_session_touch_up (XdpSession *session,
                           "NotifyTouchMotion",
                           g_variant_new ("(oa{sv}u)", session->id, &options, slot),
                           NULL, G_DBUS_CALL_FLAGS_NONE, -1, NULL, NULL, NULL);
+}
+
+/**
+ * xdp_session_get_persist_mode:
+ * @session: a #XdpSession
+ *
+ * Retrieves the effective persist mode of @session.
+ *
+ * May only be called after @session is successfully started, i.e. after
+ * xdp_session_start_finish().
+ *
+ * Returns: the effective persist mode of @session
+ */
+XdpPersistMode
+xdp_session_get_persist_mode (XdpSession *session)
+{
+  g_return_val_if_fail (XDP_IS_SESSION (session), XDP_PERSIST_MODE_NONE);
+  g_return_val_if_fail (session->state == XDP_SESSION_ACTIVE, XDP_PERSIST_MODE_NONE);
+
+  return session->persist_mode;
+}
+
+/**
+ * xdp_session_get_restore_token:
+ * @session: a #XdpSession
+ *
+ * Retrieves the restore token of @session.
+ *
+ * A restore token will only be available if #XDP_PERSIST_MODE_TRANSIENT
+ * or #XDP_PERSIST_MODE_PERSISTENT was passed when creating the screencast
+ * session.
+ *
+ * Remote desktop sessions cannot be restored.
+ *
+ * May only be called after @session is successfully started, i.e. after
+ * xdp_session_start_finish().
+ *
+ * Returns: (nullable): the restore token of @session
+ */
+char *
+xdp_session_get_restore_token (XdpSession *session)
+{
+  g_return_val_if_fail (XDP_IS_SESSION (session), NULL);
+  g_return_val_if_fail (session->state == XDP_SESSION_ACTIVE, NULL);
+
+  return g_strdup (session->restore_token);
 }

--- a/libportal/remote.h
+++ b/libportal/remote.h
@@ -110,11 +110,27 @@ typedef enum {
   XDP_CURSOR_MODE_METADATA = 1 << 2,
 } XdpCursorMode;
 
+/**
+ * XdpPersistMode:
+ * @XDP_PERSIST_MODE_NONE: do not persist
+ * @XDP_PERSIST_MODE_TRANSIENT: persist as long as the application is alive
+ * @XDP_PERSIST_MODE_PERSISTENT: persist until the user revokes this permission
+ *
+ * Options for how the screencast session should persist.
+ */
+typedef enum {
+  XDP_PERSIST_MODE_NONE,
+  XDP_PERSIST_MODE_TRANSIENT,
+  XDP_PERSIST_MODE_PERSISTENT,
+} XdpPersistMode;
+
 XDP_PUBLIC
 void        xdp_portal_create_screencast_session            (XdpPortal            *portal,
                                                              XdpOutputType         outputs,
                                                              XdpScreencastFlags    flags,
                                                              XdpCursorMode         cursor_mode,
+                                                             XdpPersistMode        persist_mode,
+                                                             const char           *restore_token,
                                                              GCancellable         *cancellable,
                                                              GAsyncReadyCallback   callback,
                                                              gpointer              data);
@@ -269,5 +285,12 @@ void      xdp_session_touch_position (XdpSession *session,
 XDP_PUBLIC
 void      xdp_session_touch_up       (XdpSession *session,
                                       guint       slot);
+
+
+XDP_PUBLIC
+XdpPersistMode  xdp_session_get_persist_mode  (XdpSession *session);
+
+XDP_PUBLIC
+char           *xdp_session_get_restore_token (XdpSession *session);
 
 G_END_DECLS

--- a/libportal/session-private.h
+++ b/libportal/session-private.h
@@ -31,6 +31,9 @@ struct _XdpSession {
   XdpDeviceType devices;
   GVariant *streams;
 
+  XdpPersistMode persist_mode;
+  char *restore_token;
+
   guint signal_id;
 };
 

--- a/libportal/session.c
+++ b/libportal/session.c
@@ -55,6 +55,7 @@ xdp_session_finalize (GObject *object)
     g_dbus_connection_signal_unsubscribe (session->portal->bus, session->signal_id);
 
   g_clear_object (&session->portal);
+  g_free (session->restore_token);
   g_free (session->id);
   g_clear_pointer (&session->streams, g_variant_unref);
 

--- a/libportal/session.c
+++ b/libportal/session.c
@@ -215,7 +215,7 @@ _xdp_session_set_devices (XdpSession *session,
  * xdp_session_get_streams:
  * @session: a #XdpSession
  *
- * Obtains the streams that the user selected. The information inthe
+ * Obtains the streams that the user selected. The information in the
  * returned #GVariant has the format `a(ua{sv})`. Each item in the array
  * is describing a stream. The first member is the pipewire node ID, the
  * second is a dictionary of stream properties, including:

--- a/portal-test/gtk3/portal-test-win.c
+++ b/portal-test/gtk3/portal-test-win.c
@@ -621,6 +621,8 @@ start_screencast (PortalTestWin *win)
                                         XDP_OUTPUT_MONITOR | XDP_OUTPUT_WINDOW,
                                         XDP_SCREENCAST_FLAG_NONE,
                                         XDP_CURSOR_MODE_HIDDEN,
+                                        XDP_PERSIST_MODE_NONE,
+                                        NULL,
                                         NULL,
                                         session_created,
                                         win);

--- a/portal-test/gtk4/window.js
+++ b/portal-test/gtk4/window.js
@@ -38,6 +38,8 @@ var PortalTestWindow = GObject.registerClass({
 
         this._portal = new Xdp.Portal();
 
+        this._restoreToken = null;
+
         // Sandbox status
         const path = GLib.build_filenamev([GLib.get_user_runtime_dir(), 'flatpak-info']);
         this._sandboxStatus.label =
@@ -539,6 +541,8 @@ var PortalTestWindow = GObject.registerClass({
                 Xdp.OutputType.WINDOW | Xdp.OutputType.MONITOR,
                 Xdp.ScreencastFlags.NONE,
                 Xdp.CursorMode.HIDDEN,
+                Xdp.PersistMode.TRANSIENT,
+                this._restoreToken,
                 null,
                 (portal, result) => {
                     try {
@@ -578,6 +582,11 @@ var PortalTestWindow = GObject.registerClass({
 
                             label += `Stream ${streamId}: ${w}x${h} @ ${x},${y}`;
                         }
+
+                        this._restoreToken = session.get_restore_token();
+                        if (this._restoreToken)
+                            label += `\nRestore token: ${this._restoreToken}`;
+
                         this._screencastLabel.label = label;
                     });
                 });


### PR DESCRIPTION
Add the XdpPersistMode enum, and modify the signature of
xdp_portal_create_screencast_session() to account for the
persist mode, and the restore token.

Add getters of the restore token and the persist mode to
XdpSession, and document that they are only available after
starting the session.

Adjust the corresponding code of portal tests. Make the GTK4
portal test exercise the transient persist mode.