### PR TITLE
build: Correct option description

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -7,6 +7,6 @@ option('introspection', type: 'boolean', value: true,
 option('vapi', type: 'boolean', value: true,
   description : 'Generate Vala bindings')
 option('docs', type: 'boolean', value: true,
-  description : 'Build API reference with gtk-doc')
+  description : 'Build API reference with gi-docgen')
 option('tests', type: 'boolean', value: true,
   description : 'Build unit tests')


### PR DESCRIPTION
Ever since the option was renamed from `gtk_doc` to `docs`, the
API reference is not built with gtk-doc :-)
