### PR TITLE
Avoid a critical in the sandbox check code

### DIFF
--- a/libportal/portal.c
+++ b/libportal/portal.c
@@ -379,7 +379,7 @@ end:
 gboolean
 xdp_portal_running_under_flatpak (void)
 {
-  static gsize under_flatpak;
+  static gsize under_flatpak = 0;
   enum {
     NOT_FLATPAK = 1,
     IS_FLATPAK  = 2

--- a/libportal/portal.c
+++ b/libportal/portal.c
@@ -380,14 +380,21 @@ gboolean
 xdp_portal_running_under_flatpak (void)
 {
   static gsize under_flatpak;
+  enum {
+    NOT_FLATPAK = 1,
+    IS_FLATPAK  = 2
+  };
 
   if (g_once_init_enter (&under_flatpak))
     {
       gboolean flatpak_info_exists = g_file_test ("/.flatpak-info", G_FILE_TEST_EXISTS);
-      g_once_init_leave (&under_flatpak, flatpak_info_exists);
+      if (flatpak_info_exists)
+        g_once_init_leave (&under_flatpak, IS_FLATPAK);
+      else
+        g_once_init_leave (&under_flatpak, NOT_FLATPAK);
     }
 
-  return under_flatpak;
+  return under_flatpak == IS_FLATPAK;
 }
 
 /**


### PR DESCRIPTION
Passing FALSE (zero) to g_once_init_leave() isn't allowed and leads to
GLib-CRITICAL **: 22:02:50.836: g_once_init_leave: assertion 'result !=0' failed

So rework xdp_portal_running_under_flatpak() a bit.