### PR TITLE
Ensure GCancellable callback is cancelled

### DIFF
--- a/libportal/account.c
+++ b/libportal/account.c
@@ -138,6 +138,12 @@ call_returned (GObject *object,
   ret = g_dbus_connection_call_finish (bus, result, &error);
   if (error)
     {
+      if (call->cancelled_id)
+        {
+          g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
+          call->cancelled_id = 0;
+        }
+
       g_task_return_error (call->task, error);
       account_call_free (call);
     }

--- a/libportal/background.c
+++ b/libportal/background.c
@@ -144,6 +144,12 @@ call_returned (GObject *object,
   ret = g_dbus_connection_call_finish (G_DBUS_CONNECTION (object), result, &error);
   if (error)
     {
+      if (call->cancelled_id)
+        {
+          g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
+          call->cancelled_id = 0;
+        }
+
       g_task_return_error (call->task, error);
       background_call_free (call);
     }

--- a/libportal/camera.c
+++ b/libportal/camera.c
@@ -157,6 +157,12 @@ call_returned (GObject *object,
   ret = g_dbus_connection_call_finish (G_DBUS_CONNECTION (object), result, &error);
   if (error)
     {
+      if (call->cancelled_id)
+        {
+          g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
+          call->cancelled_id = 0;
+        }
+
       g_task_return_error (call->task, error);
       access_camera_call_free (call);
     }

--- a/libportal/email.c
+++ b/libportal/email.c
@@ -162,6 +162,12 @@ call_returned (GObject *object,
   ret = g_dbus_connection_call_with_unix_fd_list_finish (bus, NULL, result, &error);
   if (error)
     {
+      if (call->cancelled_id)
+        {
+          g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
+          call->cancelled_id = 0;
+        }
+
       g_task_return_error (call->task, error);
       email_call_free (call);
     }

--- a/libportal/filechooser.c
+++ b/libportal/filechooser.c
@@ -157,6 +157,12 @@ call_returned (GObject *object,
   ret = g_dbus_connection_call_finish (G_DBUS_CONNECTION (object), result, &error);
   if (error)
     {
+      if (call->cancelled_id)
+        {
+          g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
+          call->cancelled_id = 0;
+        }
+
       g_task_return_error (call->task, error);
       file_call_free (call);
     }

--- a/libportal/location.c
+++ b/libportal/location.c
@@ -76,6 +76,12 @@ session_started (GDBusConnection *bus,
   guint32 response;
   g_autoptr(GVariant) ret = NULL;
 
+  if (call->cancelled_id)
+    {
+      g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
+      call->cancelled_id = 0;
+    }
+
   g_variant_get (parameters, "(u@a{sv})", &response, &ret);
 
   if (response == 0)
@@ -182,6 +188,12 @@ call_returned (GObject *object,
   ret = g_dbus_connection_call_finish (G_DBUS_CONNECTION (object), result, &error);
   if (error)
     {
+      if (call->cancelled_id)
+        {
+          g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
+          call->cancelled_id = 0;
+        }
+
       g_task_return_error (call->task, error);
       create_call_free (call);
     }

--- a/libportal/openuri.c
+++ b/libportal/openuri.c
@@ -84,6 +84,12 @@ response_received (GDBusConnection *bus,
   guint32 response;
   g_autoptr(GVariant) ret = NULL;
 
+  if (call->cancelled_id)
+    {
+      g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
+      call->cancelled_id = 0;
+    }
+
   g_variant_get (parameters, "(u@a{sv})", &response, &ret);
 
   if (response == 0)
@@ -148,6 +154,12 @@ call_returned (GObject *object,
 
   if (error)
     {
+      if (call->cancelled_id)
+        {
+          g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
+          call->cancelled_id = 0;
+        }
+
       g_task_return_error (call->task, error);
       open_call_free (call);
     }

--- a/libportal/print.c
+++ b/libportal/print.c
@@ -167,6 +167,12 @@ call_returned (GObject *object,
     ret = g_dbus_connection_call_with_unix_fd_list_finish (G_DBUS_CONNECTION (object), NULL, result, &error);
   if (error)
     {
+      if (call->cancelled_id)
+        {
+          g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
+          call->cancelled_id = 0;
+        }
+
       g_task_return_error (call->task, error);
       print_call_free (call);
     }

--- a/libportal/screenshot.c
+++ b/libportal/screenshot.c
@@ -154,6 +154,12 @@ call_returned (GObject *object,
   ret = g_dbus_connection_call_finish (G_DBUS_CONNECTION (object), result, &error);
   if (error)
     {
+      if (call->cancelled_id)
+        {
+          g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
+          call->cancelled_id = 0;
+        }
+
       g_task_return_error (call->task, error);
       screenshot_call_free (call);
     }

--- a/libportal/wallpaper.c
+++ b/libportal/wallpaper.c
@@ -83,6 +83,12 @@ response_received (GDBusConnection *bus,
   guint32 response;
   g_autoptr(GVariant) ret = NULL;
 
+  if (call->cancelled_id)
+    {
+      g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
+      call->cancelled_id = 0;
+    }
+
   g_variant_get (parameters, "(u@a{sv})", &response, &ret);
 
   if (response == 0)
@@ -147,6 +153,12 @@ call_returned (GObject *object,
 
   if (error)
     {
+      if (call->cancelled_id)
+        {
+          g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
+          call->cancelled_id = 0;
+        }
+
       g_task_return_error (call->task, error);
       wallpaper_call_free (call);
     }


### PR DESCRIPTION
Currently, for most portals, we cancel the callback for the task's
GCancellable in the response_received() function, which is reached when
the method call was successful. However when the method call was not
successful, the call_returned() or similar function is reached, and we call
g_task_return_error() without disconnecting the cancellable_cb(). This
is an issue because the application code using libportal may decide to
call g_cancellable_cancel() on its GCancellable as part of cleaning up
state after the portal call fails, and this would lead to us returning
the task twice, causing a critical warning (from GLib's g_return_if_fail
(!task->ever_returned);) and a seg fault when we try to free the already
freed Call data.

This happens because even though we already call the free function on
the error code path in call_returned(), and the free function cancels
the cancellable_cb(), the cancellable_cb() is invoked before we reach
that, since it's invoked as part of the g_task_return_error() invoked by
call_returned(). Therefore we get in a state where the task has already
been returned but the cancellable_cb() not disconnected, and we try to
return it again in cancellable_cb().

This patch fixes the issue by disconnecting the cancellable cb on all
the code paths where we return the GTask and on which the cancellable cb
has already been set. This matches what we're already doing in
response_received() in many places. Another possible implementation,
which I've already verified works, is to add a g_task_had_error() check
in cancellable_cb() and do an early return (though you cannot use
g_task_get_completed() so it only helps for the error code paths). I'm
not sure which implementation is better.

I saw this when working on the dynamic launcher portal since Epiphany
calls g_cancellable_cancel() in src/window-commands.c when installing a
web app.