### PR TITLE
libportal-qt: make filechooserFilterToGVariant() public

### DIFF
--- a/libportal/portal-qt5.cpp
+++ b/libportal/portal-qt5.cpp
@@ -116,7 +116,7 @@ getUserInformationResultFromGVariant(GVariant *variant)
     return result;
 }
 
-static GVariant *
+GVariant *
 filechooserFilterToGVariant(const FileChooserFilter &filter)
 {
     GVariantBuilder builder;

--- a/libportal/portal-qt5.h
+++ b/libportal/portal-qt5.h
@@ -74,6 +74,9 @@ XDP_PUBLIC
 GVariant *filechooserFilesToGVariant(const QStringList &files);
 
 XDP_PUBLIC
+GVariant *filechooserFilterToGVariant(const FileChooserFilter &filter);
+
+XDP_PUBLIC
 GVariant *filechooserFiltersToGVariant(const QList<FileChooserFilter> &filters);
 
 XDP_PUBLIC


### PR DESCRIPTION
This will be useful in xdp_portal_open_file() where 'current_filter' option expects just one filter and not a list.