### PR TITLE
wallpaper: annotate the parent window as nullalble

### DIFF
--- a/libportal/wallpaper.c
+++ b/libportal/wallpaper.c
@@ -278,7 +278,7 @@ set_wallpaper (WallpaperCall *call)
 /**
  * xdp_portal_set_wallpaper:
  * @portal: a [class@Portal]
- * @parent: parent window information
+ * @parent: (nullable): parent window information
  * @uri: the URI to use
  * @flags: options for this call
  * @cancellable: (nullable): optional [class@Gio.Cancellable]


### PR DESCRIPTION
The C code allows for it to be NULL, let's make this in the bindings too
so we don't have to instantiate windows to test this.