### PR TITLE
test: add a pytest/dbusmock-based test suite

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libglib2.0 gettext dbus meson libgirepository1.0-dev libgtk-3-dev valac
+          sudo apt-get install -y libglib2.0 gettext dbus meson libgirepository1.0-dev libgtk-3-dev valac python3-pytest python3-dbusmock
       - name: Check out libportal
         uses: actions/checkout@v1
       - name: Configure libportal
@@ -55,7 +55,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update
-          apt-get install -y libglib2.0 gettext dbus meson libgirepository1.0-dev libgtk-3-dev libgtk-4-dev valac python3-pip
+          apt-get install -y libglib2.0 gettext dbus meson libgirepository1.0-dev libgtk-3-dev libgtk-4-dev valac python3-pip python3-dbusmock
           pip3 install gi-docgen
           echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: Check out libportal
@@ -73,7 +73,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          dnf install -y meson gcc gobject-introspection-devel gtk3-devel gtk4-devel gi-docgen vala git
+          dnf install -y meson gcc gobject-introspection-devel gtk3-devel gtk4-devel gi-docgen vala git python3-pytest python3-dbusmock
       - name: Check out libportal
         uses: actions/checkout@v1
       - name: Configure libportal

--- a/tests/gir-testenv.sh
+++ b/tests/gir-testenv.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+#
+# Wrapper to set up the right environment variables and start a nested
+# shell. Usage:
+#
+# $ ./tests/gir-testenv.sh
+# (nested shell) $ pytest
+# (nested shell) $ exit
+#
+# If you have meson 0.58 or later, you can instead do:
+# $ meson devenv -C builddir
+# (nested shell) $ cd ../tests
+# (nested shell) $ pytest
+# (nested shell) $ exit
+#
+
+builddir=$(find $PWD -name meson-logs -printf "%h" -quit)
+
+if [ -z "$builddir" ]; then
+    echo "Unable to find meson builddir"
+    exit 1
+fi
+
+echo "Using meson builddir: $builddir"
+
+export LD_LIBRARY_PATH="$builddir/libportal:$LD_LIBRARY_PATH"
+export GI_TYPELIB_PATH="$builddir/libportal:$GI_TYPELIB_PATH"
+
+echo "pytest must be run from within the tests/ directory"
+# Don't think this is portable, but oh well
+${SHELL}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,3 +1,22 @@
 if 'qt5' in backends
   subdir('qt5')
 endif
+
+if meson.version().version_compare('>= 0.56.0')
+  pytest = find_program('pytest-3', 'pytest', required: false)
+  pymod = import('python')
+  python = pymod.find_installation('python3', modules: ['dbus', 'dbusmock'], required: false)
+
+  if pytest.found() and python.found()
+    test_env = environment()
+    test_env.set('LD_LIBRARY_PATH', meson.project_build_root() / 'libportal')
+    test_env.set('GI_TYPELIB_PATH', meson.project_build_root() / 'libportal')
+
+    test('pytest',
+      pytest,
+      args: ['--verbose', '--log-level=DEBUG'],
+      env: test_env,
+      workdir: meson.current_source_dir()
+    )
+  endif
+endif

--- a/tests/pyportaltest/__init__.py
+++ b/tests/pyportaltest/__init__.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: LGPL-3.0-only
+#
+# This file is formatted with Python Black
+
+from typing import Any, Dict, List, Tuple
+
+import gi
+from gi.repository import GLib
+from dbus.mainloop.glib import DBusGMainLoop
+
+import dbus
+import dbusmock
+import fcntl
+import logging
+import os
+import pytest
+import subprocess
+
+logging.basicConfig(format="%(levelname)s | %(name)s: %(message)s", level=logging.DEBUG)
+logger = logging.getLogger("pyportaltest")
+
+DBusGMainLoop(set_as_default=True)
+
+# Uncomment this to have dbus-monitor listen on the normal session address
+# rather than the test DBus. This can be useful for cases where *something*
+# messes up and tests run against the wrong bus.
+#
+# session_dbus_address = os.environ["DBUS_SESSION_BUS_ADDRESS"]
+
+
+def start_dbus_monitor() -> "subprocess.Process":
+    import subprocess
+
+    env = os.environ.copy()
+    try:
+        env["DBUS_SESSION_BUS_ADDRESS"] = session_dbus_address
+    except NameError:
+        # See comment above
+        pass
+
+    argv = ["dbus-monitor", "--session"]
+    mon = subprocess.Popen(argv, env=env)
+
+    def stop_dbus_monitor():
+        mon.terminate()
+        mon.wait()
+
+    GLib.timeout_add(2000, stop_dbus_monitor)
+    return mon
+
+
+class PortalTest(dbusmock.DBusTestCase):
+    """
+    Parent class for portal tests. Subclass from this and name it after the
+    portal, e.g. ``TestWallpaper``.
+
+    .. attribute:: portal_interface
+
+        The :class:`dbus.Interface` referring to our portal
+
+    .. attribute:: properties_interface
+
+        A convenience :class:`dbus.Interface` referring to the DBus Properties
+        interface, call ``Get``, ``Set`` or ``GetAll`` on this interface to
+        retrieve the matching property/properties.
+
+    .. attribute:: mock_interface
+
+        The DBusMock :class:`dbus.Interface` that controls our DBus
+        appearance.
+
+    """
+    @classmethod
+    def setUpClass(cls):
+        if cls.__name__ != "PortalTest":
+            cls.PORTAL_NAME = cls.__name__.removeprefix("Test")
+            cls.INTERFACE_NAME = f"org.freedesktop.portal.{cls.PORTAL_NAME}"
+        os.environ["LIBPORTAL_TEST_SUITE"] = "1"
+
+        try:
+            dbusmock.mockobject.DBusMockObject.EmitSignalDetailed
+        except AttributeError:
+            pytest.skip("Updated version of dbusmock required")
+
+    def setUp(self):
+        self.p_mock = None
+        self._mainloop = None
+        self.dbus_monitor = None
+
+    def setup_daemon(self, params=None):
+        """
+        Start a DBusMock daemon in a separate process
+        """
+        self.start_session_bus()
+        self.p_mock, self.obj_portal = self.spawn_server_template(
+            template=f"pyportaltest/templates/{self.PORTAL_NAME.lower()}.py",
+            parameters=params,
+            stdout=subprocess.PIPE,
+        )
+        flags = fcntl.fcntl(self.p_mock.stdout, fcntl.F_GETFL)
+        fcntl.fcntl(self.p_mock.stdout, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+        self.mock_interface = dbus.Interface(self.obj_portal, dbusmock.MOCK_IFACE)
+        self.properties_interface = dbus.Interface(
+            self.obj_portal, dbus.PROPERTIES_IFACE
+        )
+        self.portal_interface = dbus.Interface(self.obj_portal, self.INTERFACE_NAME)
+
+        self.dbus_monitor = start_dbus_monitor()
+
+    def tearDown(self):
+        if self.p_mock:
+            if self.p_mock.stdout:
+                out = (self.p_mock.stdout.read() or b"").decode("utf-8")
+                if out:
+                    print(out)
+                self.p_mock.stdout.close()
+            self.p_mock.terminate()
+            self.p_mock.wait()
+
+        if self.dbus_monitor:
+            self.dbus_monitor.terminate()
+            self.dbus_monitor.wait()
+
+    @property
+    def mainloop(self):
+        """
+        The mainloop for this test. This mainloop automatically quits after a
+        fixed timeout, but only on the first run. That's usually enough for
+        tests, if you need to call mainloop.run() repeatedly ensure that a
+        timeout handler is set to ensure quick test case failure  in case of
+        error.
+        """
+        if self._mainloop is None:
+
+            def quit():
+                self._mainloop.quit()
+                self._mainloop = None
+
+            self._mainloop = GLib.MainLoop()
+            GLib.timeout_add(2000, quit)
+
+        return self._mainloop
+
+    def assert_version_eq(self, version: int):
+        """Assert the given version number is the one our portal exports"""
+        interface_name = self.INTERFACE_NAME
+        params = {}
+        self.setup_daemon(params)
+        assert self.properties_interface.Get(interface_name, "version") == version

--- a/tests/pyportaltest/templates/__init__.py
+++ b/tests/pyportaltest/templates/__init__.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: LGPL-3.0-only
+#
+# This file is formatted with Python Black
+
+from dbusmock import DBusMockObject
+from typing import Dict, Any, NamedTuple, Optional
+from itertools import count
+from gi.repository import GLib
+
+import dbus
+import logging
+
+
+ASVType = Dict[str, Any]
+
+logging.basicConfig(format="%(levelname).1s|%(name)s: %(message)s", level=logging.DEBUG)
+logger = logging.getLogger("templates")
+
+
+class Response(NamedTuple):
+    response: int
+    results: ASVType
+
+
+class Request:
+    _token_counter = count()
+
+    def __init__(
+        self, bus_name: dbus.service.BusName, sender: str, options: Optional[ASVType]
+    ):
+        options = options or {}
+        sender_token = sender.removeprefix(":").replace(".", "_")
+        handle_token = options.get("handle_token", next(self._token_counter))
+        self.sender = sender
+        self.handle = (
+            f"/org/freedesktop/portal/desktop/request/{sender_token}/{handle_token}"
+        )
+        self.mock = DBusMockObject(
+            bus_name=bus_name,
+            path=self.handle,
+            interface="org.freedesktop.portal.Request",
+            props={},
+        )
+        self.mock.AddMethod("", "Close", "", "", "self.RemoveObject(self.path)")
+
+    def respond(self, response: Response, delay: int = 0):
+        def respond():
+            logger.debug(f"Request.Response on {self.handle}: {response}")
+            self.mock.EmitSignalDetailed(
+                "",
+                "Response",
+                "ua{sv}",
+                [dbus.UInt32(response.response), response.results],
+                details={"destination": self.sender},
+            )
+
+        if delay > 0:
+            GLib.timeout_add(delay, respond)
+        else:
+            respond()
+
+
+class Session:
+    _token_counter = count()
+
+    def __init__(
+        self, bus_name: dbus.service.BusName, sender: str, options: Optional[ASVType]
+    ):
+        options = options or {}
+        sender_token = sender.removeprefix(":").replace(".", "_")
+        handle_token = options.get("session_handle_token", next(self._token_counter))
+        self.sender = sender
+        self.handle = (
+            f"/org/freedesktop/portal/desktop/session/{sender_token}/{handle_token}"
+        )
+        self.mock = DBusMockObject(
+            bus_name=bus_name,
+            path=self.handle,
+            interface="org.freedesktop.portal.Session",
+            props={},
+        )
+        self.mock.AddMethod("", "Close", "", "", "self.RemoveObject(self.path)")
+
+    def close(self, details: ASVType, delay: int = 0):
+        def respond():
+            logger.debug(f"Session.Closed on {self.handle}: {details}")
+            self.mock.EmitSignalDetailed(
+                "", "Closed", "a{sv}", [details], destination=self.sender
+            )
+
+        if delay > 0:
+            GLib.timeout_add(delay, respond)
+        else:
+            respond()

--- a/tests/pyportaltest/templates/wallpaper.py
+++ b/tests/pyportaltest/templates/wallpaper.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: LGPL-3.0-only
+#
+# This file is formatted with Python Black
+
+from pyportaltest.templates import Request, Response, ASVType
+from typing import Dict, List, Tuple, Iterator
+
+import dbus.service
+import logging
+
+logger = logging.getLogger(f"templates.{__name__}")
+
+BUS_NAME = "org.freedesktop.portal.Desktop"
+MAIN_OBJ = "/org/freedesktop/portal/desktop"
+SYSTEM_BUS = False
+MAIN_IFACE = "org.freedesktop.portal.Wallpaper"
+
+
+def load(mock, parameters=None):
+    logger.debug(f"loading {MAIN_IFACE} template")
+    mock.delay = 500
+
+    mock.response = parameters.get("response", 0)
+
+    mock.AddProperties(
+        MAIN_IFACE,
+        dbus.Dictionary({"version": dbus.UInt32(parameters.get("version", 1))}),
+    )
+
+
+@dbus.service.method(
+    MAIN_IFACE,
+    sender_keyword="sender",
+    in_signature="ssa{sv}",
+    out_signature="o",
+)
+def SetWallpaperURI(self, parent_window, uri, options, sender):
+    try:
+        logger.debug(f"SetWallpaperURI: {parent_window}, {uri}, {options}")
+        request = Request(bus_name=self.bus_name, sender=sender, options=options)
+
+        response = Response(self.response, {})
+
+        request.respond(response, delay=self.delay)
+
+        return request.handle
+    except Exception as e:
+        logger.critical(e)

--- a/tests/pyportaltest/test_wallpaper.py
+++ b/tests/pyportaltest/test_wallpaper.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: LGPL-3.0-only
+#
+# This file is formatted with Python Black
+
+from . import PortalTest
+
+import gi
+import logging
+
+gi.require_version("Xdp", "1.0")
+from gi.repository import GLib, Xdp
+
+logger = logging.getLogger(__name__)
+
+
+class TestWallpaper(PortalTest):
+    def test_version(self):
+        self.assert_version_eq(1)
+
+    def set_wallpaper(
+        self, uri_to_set: str, set_on: Xdp.WallpaperFlags, show_preview: bool
+    ):
+        params = {}
+        self.setup_daemon(params)
+
+        xdp = Xdp.Portal.new()
+        assert xdp is not None
+
+        flags = {
+            "background": Xdp.WallpaperFlags.BACKGROUND,
+            "lockscreen": Xdp.WallpaperFlags.LOCKSCREEN,
+            "both": Xdp.WallpaperFlags.BACKGROUND | Xdp.WallpaperFlags.LOCKSCREEN,
+        }[set_on]
+
+        if show_preview:
+            flags |= Xdp.WallpaperFlags.PREVIEW
+
+        wallpaper_was_set = False
+
+        def set_wallpaper_done(portal, task, data):
+            nonlocal wallpaper_was_set
+            wallpaper_was_set = portal.set_wallpaper_finish(task)
+            self.mainloop.quit()
+
+        xdp.set_wallpaper(
+            parent=None,
+            uri=uri_to_set,
+            flags=flags,
+            cancellable=None,
+            callback=set_wallpaper_done,
+            data=None,
+        )
+
+        self.mainloop.run()
+
+        method_calls = self.mock_interface.GetMethodCalls("SetWallpaperURI")
+        assert len(method_calls) == 1
+        timestamp, args = method_calls.pop(0)
+        parent, uri, options = args
+        assert uri == uri_to_set
+        assert options["set-on"] == set_on
+        assert options["show-preview"] == show_preview
+
+        assert wallpaper_was_set
+
+    def test_set_wallpaper_background(self):
+        self.set_wallpaper("https://background.nopreview", "background", False)
+
+    def test_set_wallpaper_background_preview(self):
+        self.set_wallpaper("https://background.preview", "background", True)
+
+    def test_set_wallpaper_lockscreen(self):
+        self.set_wallpaper("https://lockscreen.nopreview", "lockscreen", False)
+
+    def test_set_wallpaper_lockscreen_preview(self):
+        self.set_wallpaper("https://lockscreen.preview", "lockscreen", True)
+
+    def test_set_wallpaper_both(self):
+        self.set_wallpaper("https://both.nopreview", "both", False)
+
+    def test_set_wallpaper_both_preview(self):
+        self.set_wallpaper("https://both.preview", "both", True)
+
+    def test_set_wallpaper_cancel(self):
+        params = {"response": 1}
+        self.setup_daemon(params)
+
+        xdp = Xdp.Portal.new()
+        assert xdp is not None
+
+        flags = Xdp.WallpaperFlags.BACKGROUND
+
+        wallpaper_was_set = False
+
+        def set_wallpaper_done(portal, task, data):
+            nonlocal wallpaper_was_set
+            try:
+                wallpaper_was_set = portal.set_wallpaper_finish(task)
+            except GLib.GError:
+                pass
+            self.mainloop.quit()
+
+        xdp.set_wallpaper(
+            parent=None,
+            uri="https://ignored.anyway",
+            flags=flags,
+            cancellable=None,
+            callback=set_wallpaper_done,
+            data=None,
+        )
+
+        self.mainloop.run()
+
+        method_calls = self.mock_interface.GetMethodCalls("SetWallpaperURI")
+        assert len(method_calls) == 1
+
+        assert not wallpaper_was_set


### PR DESCRIPTION
Using python and dbusmock makes it trivial to add a large number of
tests for libportal only, without requiring an actual portal
implementation for the Portal interface to be tested.

Included here is the wallpaper portal as an example, hooked into meson test.
A helper script is provided too for those lacking `meson devenv`,
```
  $ ./test/gir-testenv.sh
  $ cd test
  $ pytest --verbose --log-level=DEBUG [... other pytest arguments ...]
```
The test setup uses dbusmock interface templates (see
pyportaltest/templates) to handle the actual DBus calls.

Because DBus uses a singleton for the session bus, we need libportal to
specifically connect to the address given in the environment - otherwise
starting mock dbus services has no effect.

This test suite depends on [dbusmock commit 4a191d8ba293:
"mockobject: allow sending signals with extra details"](https://github.com/martinpitt/python-dbusmock/pull/129)

Without this, the `EmitSignalDetailed()` method does not exist/work, but
without this method we cannot receive signals.