### PR TITLE
ci: use the predefined env var for the git sha

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,4 +107,4 @@ jobs:
       - name: Check out libportal
         uses: actions/checkout@v1
       - name: Run ABI check
-        run: check-abi --old-parameters="-Dvapi=false -Ddocs=false -Dintrospection=false" --new-parameters="-Dvapi=false -Ddocs=false -Dtests=false -Dintrospection=false" ${LAST_ABI_BREAK} $(git rev-parse HEAD)
+        run: check-abi --old-parameters="-Dvapi=false -Ddocs=false -Dintrospection=false" --new-parameters="-Dvapi=false -Ddocs=false -Dtests=false -Dintrospection=false" ${LAST_ABI_BREAK} $GITHUB_SHA

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,5 +106,7 @@ jobs:
           rm -rf check-abi/
       - name: Check out libportal
         uses: actions/checkout@v1
+      - name: Work around git safe directory check
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
       - name: Run ABI check
         run: check-abi --old-parameters="-Dvapi=false -Ddocs=false -Dintrospection=false" --new-parameters="-Dvapi=false -Ddocs=false -Dtests=false -Dintrospection=false" ${LAST_ABI_BREAK} $GITHUB_SHA


### PR DESCRIPTION
We have a predefined variable for it, let's use it

This also fixes the current issues with the `check-abi` job - new git is unhappy about the owner of the cloned repository

cc @hadess 
