### PR TITLE
Subclass RemoteDesktop/ScreenCast sessions from XdpSession

### DIFF
--- a/libportal/meson.build
+++ b/libportal/meson.build
@@ -19,6 +19,7 @@ headers = [
   'print.h',
   'remote.h',
   'screenshot.h',
+  'session.h',
   'spawn.h',
   'trash.h',
   'types.h',

--- a/libportal/portal.h
+++ b/libportal/portal.h
@@ -34,6 +34,7 @@
 #include <libportal/print.h>
 #include <libportal/remote.h>
 #include <libportal/screenshot.h>
+#include <libportal/session.h>
 #include <libportal/spawn.h>
 #include <libportal/trash.h>
 #include <libportal/types.h>

--- a/libportal/remote.c
+++ b/libportal/remote.c
@@ -846,6 +846,16 @@ xdp_session_open_pipewire_remote (XdpSession *session)
   return g_unix_fd_list_get (fd_list, fd_out, NULL);
 }
 
+static gboolean
+is_active_remotedesktop_session (XdpSession    *session,
+                                 XdpDeviceType  required_device)
+{
+  return XDP_IS_SESSION (session) &&
+         session->type == XDP_SESSION_REMOTE_DESKTOP &&
+         session->state == XDP_SESSION_ACTIVE &&
+         (session->devices & required_device) != 0;
+}
+
 /**
  * xdp_session_pointer_motion:
  * @session: a [class@Session]
@@ -864,10 +874,7 @@ xdp_session_pointer_motion (XdpSession *session,
 {
   GVariantBuilder options;
 
-  g_return_if_fail (XDP_IS_SESSION (session) &&
-                    session->type == XDP_SESSION_REMOTE_DESKTOP &&
-                    session->state == XDP_SESSION_ACTIVE &&
-                    ((session->devices & XDP_DEVICE_POINTER) != 0));
+  g_return_if_fail (is_active_remotedesktop_session (session, XDP_DEVICE_POINTER));
 
   g_variant_builder_init (&options, G_VARIANT_TYPE_VARDICT);
   g_dbus_connection_call (session->portal->bus,
@@ -900,10 +907,7 @@ xdp_session_pointer_position (XdpSession *session,
 {
   GVariantBuilder options;
 
-  g_return_if_fail (XDP_IS_SESSION (session) &&
-                    session->type == XDP_SESSION_REMOTE_DESKTOP &&
-                    session->state == XDP_SESSION_ACTIVE &&
-                    ((session->devices & XDP_DEVICE_POINTER) != 0));
+  g_return_if_fail (is_active_remotedesktop_session (session, XDP_DEVICE_POINTER));
 
   g_variant_builder_init (&options, G_VARIANT_TYPE_VARDICT);
   g_dbus_connection_call (session->portal->bus,
@@ -933,10 +937,7 @@ xdp_session_pointer_button (XdpSession *session,
 {
   GVariantBuilder options;
 
-  g_return_if_fail (XDP_IS_SESSION (session) &&
-                    session->type == XDP_SESSION_REMOTE_DESKTOP &&
-                    session->state == XDP_SESSION_ACTIVE &&
-                    ((session->devices & XDP_DEVICE_POINTER) != 0));
+  g_return_if_fail (is_active_remotedesktop_session (session, XDP_DEVICE_POINTER));
 
   g_variant_builder_init (&options, G_VARIANT_TYPE_VARDICT);
   g_dbus_connection_call (session->portal->bus,
@@ -970,10 +971,7 @@ xdp_session_pointer_axis (XdpSession *session,
 {
   GVariantBuilder options;
 
-  g_return_if_fail (XDP_IS_SESSION (session) &&
-                    session->type == XDP_SESSION_REMOTE_DESKTOP &&
-                    session->state == XDP_SESSION_ACTIVE &&
-                    ((session->devices & XDP_DEVICE_POINTER) != 0));
+  g_return_if_fail (is_active_remotedesktop_session (session, XDP_DEVICE_POINTER));
 
   g_variant_builder_init (&options, G_VARIANT_TYPE_VARDICT);
   g_variant_builder_add (&options, "{sv}", "finish", g_variant_new_boolean (finish));
@@ -1004,10 +1002,7 @@ xdp_session_pointer_axis_discrete (XdpSession *session,
 {
   GVariantBuilder options;
 
-  g_return_if_fail (XDP_IS_SESSION (session) &&
-                    session->type == XDP_SESSION_REMOTE_DESKTOP &&
-                    session->state == XDP_SESSION_ACTIVE &&
-                    ((session->devices & XDP_DEVICE_POINTER) != 0));
+  g_return_if_fail (is_active_remotedesktop_session (session, XDP_DEVICE_POINTER));
 
   g_variant_builder_init (&options, G_VARIANT_TYPE_VARDICT);
   g_dbus_connection_call (session->portal->bus,
@@ -1039,10 +1034,7 @@ xdp_session_keyboard_key (XdpSession *session,
 {
   GVariantBuilder options;
 
-  g_return_if_fail (XDP_IS_SESSION (session) &&
-                    session->type == XDP_SESSION_REMOTE_DESKTOP &&
-                    session->state == XDP_SESSION_ACTIVE &&
-                    ((session->devices & XDP_DEVICE_KEYBOARD) != 0));
+  g_return_if_fail (is_active_remotedesktop_session (session, XDP_DEVICE_KEYBOARD));
 
   g_variant_builder_init (&options, G_VARIANT_TYPE_VARDICT);
   g_dbus_connection_call (session->portal->bus,
@@ -1079,10 +1071,7 @@ xdp_session_touch_down (XdpSession *session,
 {
   GVariantBuilder options;
 
-  g_return_if_fail (XDP_IS_SESSION (session) &&
-                    session->type == XDP_SESSION_REMOTE_DESKTOP &&
-                    session->state == XDP_SESSION_ACTIVE &&
-                    ((session->devices & XDP_DEVICE_TOUCHSCREEN) != 0));
+  g_return_if_fail (is_active_remotedesktop_session (session, XDP_DEVICE_TOUCHSCREEN));
 
   g_variant_builder_init (&options, G_VARIANT_TYPE_VARDICT);
   g_dbus_connection_call (session->portal->bus,
@@ -1119,10 +1108,7 @@ xdp_session_touch_position (XdpSession *session,
 {
   GVariantBuilder options;
 
-  g_return_if_fail (XDP_IS_SESSION (session) &&
-                    session->type == XDP_SESSION_REMOTE_DESKTOP &&
-                    session->state == XDP_SESSION_ACTIVE &&
-                    ((session->devices & XDP_DEVICE_TOUCHSCREEN) != 0));
+  g_return_if_fail (is_active_remotedesktop_session (session, XDP_DEVICE_TOUCHSCREEN));
 
   g_variant_builder_init (&options, G_VARIANT_TYPE_VARDICT);
   g_dbus_connection_call (session->portal->bus,
@@ -1150,10 +1136,7 @@ xdp_session_touch_up (XdpSession *session,
 {
   GVariantBuilder options;
 
-  g_return_if_fail (XDP_IS_SESSION (session) &&
-                    session->type == XDP_SESSION_REMOTE_DESKTOP &&
-                    session->state == XDP_SESSION_ACTIVE &&
-                    ((session->devices & XDP_DEVICE_TOUCHSCREEN) != 0));
+  g_return_if_fail (is_active_remotedesktop_session (session, XDP_DEVICE_TOUCHSCREEN));
 
   g_variant_builder_init (&options, G_VARIANT_TYPE_VARDICT);
   g_dbus_connection_call (session->portal->bus,

--- a/libportal/remote.c
+++ b/libportal/remote.c
@@ -777,33 +777,6 @@ xdp_session_start_finish (XdpSession *session,
 }
 
 /**
- * xdp_session_close:
- * @session: an active [class@Session]
- *
- * Closes the session.
- */
-void
-xdp_session_close (XdpSession *session)
-{
-  XdpPortal *portal;
-
-  g_return_if_fail (XDP_IS_SESSION (session));
-
-  portal = _xdp_session_get_portal (session);
-
-  g_dbus_connection_call (portal->bus,
-                          PORTAL_BUS_NAME,
-                          _xdp_session_get_id (session),
-                          SESSION_INTERFACE,
-                          "Close",
-                          NULL,
-                          NULL, 0, -1, NULL, NULL, NULL);
-
-  _xdp_session_set_session_state (session, XDP_SESSION_CLOSED);
-  g_signal_emit_by_name (session, "closed");
-}
-
-/**
  * xdp_session_open_pipewire_remote:
  * @session: a [class@Session]
  *

--- a/libportal/remote.h
+++ b/libportal/remote.h
@@ -20,13 +20,9 @@
 #pragma once
 
 #include <libportal/types.h>
+#include <libportal/session.h>
 
 G_BEGIN_DECLS
-
-#define XDP_TYPE_SESSION (xdp_session_get_type ())
-
-XDP_PUBLIC
-G_DECLARE_FINAL_TYPE (XdpSession, xdp_session, XDP, SESSION, GObject)
 
 /**
  * XdpOutputType:
@@ -59,32 +55,6 @@ typedef enum {
   XDP_DEVICE_POINTER     = 1 << 1,
   XDP_DEVICE_TOUCHSCREEN = 1 << 2
 } XdpDeviceType;
-
-/**
- * XdpSessionType:
- * @XDP_SESSION_SCREENCAST: a screencast session.
- * @XDP_SESSION_REMOTE_DESKTOP: a remote desktop session.
- *
- * The type of a session.
- */
-typedef enum {
-  XDP_SESSION_SCREENCAST,
-  XDP_SESSION_REMOTE_DESKTOP
-} XdpSessionType;
-
-/**
- * XdpSessionState:
- * @XDP_SESSION_INITIAL: the session has not been started.
- * @XDP_SESSION_ACTIVE: the session is active.
- * @XDP_SESSION_CLOSED: the session is no longer active.
- *
- * The state of a session.
- */
-typedef enum {
-  XDP_SESSION_INITIAL,
-  XDP_SESSION_ACTIVE,
-  XDP_SESSION_CLOSED
-} XdpSessionState;
 
 /**
  * XdpScreencastFlags:
@@ -182,16 +152,7 @@ gboolean    xdp_session_start_finish         (XdpSession           *session,
                                               GError              **error);
 
 XDP_PUBLIC
-void        xdp_session_close                (XdpSession           *session);
-
-XDP_PUBLIC
 int         xdp_session_open_pipewire_remote (XdpSession           *session);
-
-XDP_PUBLIC
-XdpSessionType  xdp_session_get_session_type  (XdpSession *session);
-
-XDP_PUBLIC
-XdpSessionState xdp_session_get_session_state (XdpSession *session);
 
 XDP_PUBLIC
 XdpDeviceType   xdp_session_get_devices       (XdpSession *session);

--- a/libportal/remote.h
+++ b/libportal/remote.h
@@ -24,6 +24,16 @@
 
 G_BEGIN_DECLS
 
+#define XDP_TYPE_SCREENCAST_SESSION (xdp_screencast_session_get_type ())
+
+XDP_PUBLIC
+G_DECLARE_DERIVABLE_TYPE (XdpScreenCastSession, xdp_screencast_session, XDP, SCREENCAST_SESSION, XdpSession)
+
+#define XDP_TYPE_REMOTEDESKTOP_SESSION (xdp_remotedesktop_session_get_type ())
+
+XDP_PUBLIC
+G_DECLARE_DERIVABLE_TYPE (XdpRemoteDesktopSession, xdp_remotedesktop_session, XDP, REMOTEDESKTOP_SESSION, XdpScreenCastSession)
+
 /**
  * XdpOutputType:
  * @XDP_OUTPUT_NONE: do not select any output

--- a/libportal/remote.h
+++ b/libportal/remote.h
@@ -50,7 +50,7 @@ typedef enum {
  * @XDP_DEVICE_KEYBOARD: control the keyboard.
  * @XDP_DEVICE_POINTER: control the pointer.
  * @XDP_DEVICE_TOUCHSCREEN: control the touchscreen.
- * 
+ *
  * Flags to specify what input devices to control for a remote desktop session.
  */
 typedef enum {
@@ -242,8 +242,8 @@ void      xdp_session_pointer_axis   (XdpSession     *session,
  * the discrete scroll axes.
  */
 typedef enum {
-  XDP_AXIS_HORIZONTAL_SCROLL = 0, 
-  XDP_AXIS_VERTICAL_SCROLL   = 1 
+  XDP_AXIS_HORIZONTAL_SCROLL = 0,
+  XDP_AXIS_VERTICAL_SCROLL   = 1
 } XdpDiscreteAxis;
 
 XDP_PUBLIC
@@ -266,7 +266,7 @@ typedef enum {
 
 XDP_PUBLIC
 void      xdp_session_keyboard_key   (XdpSession *session,
-                                      gboolean    keysym, 
+                                      gboolean    keysym,
                                       int         key,
                                       XdpKeyState state);
 

--- a/libportal/session-private.h
+++ b/libportal/session-private.h
@@ -41,11 +41,27 @@ XdpSession * _xdp_session_new (XdpPortal *portal,
                                const char *id,
                                XdpSessionType type);
 
+const char * _xdp_session_get_id (XdpSession *session);
+
+XdpPortal  * _xdp_session_get_portal (XdpSession *session);
+
 void         _xdp_session_set_session_state (XdpSession *session,
                                              XdpSessionState state);
 
 void         _xdp_session_set_devices (XdpSession *session,
                                        XdpDeviceType devices);
 
+XdpDeviceType _xdp_session_get_devices (XdpSession *session);
+
 void         _xdp_session_set_streams (XdpSession *session,
                                        GVariant   *streams);
+
+void         _xdp_session_set_persist_mode (XdpSession *session,
+                                            XdpPersistMode persist_mode);
+
+void         _xdp_session_set_restore_token (XdpSession *session,
+                                             char *restore_token);
+
+const char * _xdp_session_get_restore_token (XdpSession *session);
+
+XdpPersistMode _xdp_session_get_persist_mode (XdpSession *session);

--- a/libportal/session-private.h
+++ b/libportal/session-private.h
@@ -30,9 +30,10 @@ struct _XdpSessionClass
   gpointer padding[24];
 };
 
-XdpSession * _xdp_session_new (XdpPortal *portal,
-                               const char *id,
-                               XdpSessionType type);
+void         _xdp_session_init (XdpSession *session,
+                                XdpPortal *portal,
+                                const char *id,
+                                XdpSessionType type);
 
 const char * _xdp_session_get_id (XdpSession *session);
 
@@ -40,21 +41,3 @@ XdpPortal  * _xdp_session_get_portal (XdpSession *session);
 
 void         _xdp_session_set_session_state (XdpSession *session,
                                              XdpSessionState state);
-
-void         _xdp_session_set_devices (XdpSession *session,
-                                       XdpDeviceType devices);
-
-XdpDeviceType _xdp_session_get_devices (XdpSession *session);
-
-void         _xdp_session_set_streams (XdpSession *session,
-                                       GVariant   *streams);
-
-void         _xdp_session_set_persist_mode (XdpSession *session,
-                                            XdpPersistMode persist_mode);
-
-void         _xdp_session_set_restore_token (XdpSession *session,
-                                             char *restore_token);
-
-const char * _xdp_session_get_restore_token (XdpSession *session);
-
-XdpPersistMode _xdp_session_get_persist_mode (XdpSession *session);

--- a/libportal/session-private.h
+++ b/libportal/session-private.h
@@ -21,20 +21,13 @@
 
 #include <libportal/remote.h>
 
-struct _XdpSession {
-  GObject parent_instance;
+struct _XdpSessionClass
+{
+  GObjectClass parent_class;
 
-  XdpPortal *portal;
-  char *id;
-  XdpSessionType type;
-  XdpSessionState state;
-  XdpDeviceType devices;
-  GVariant *streams;
+  void (*close) (XdpSession *session);
 
-  XdpPersistMode persist_mode;
-  char *restore_token;
-
-  guint signal_id;
+  gpointer padding[24];
 };
 
 XdpSession * _xdp_session_new (XdpPortal *portal,

--- a/libportal/session.c
+++ b/libportal/session.c
@@ -55,8 +55,8 @@ xdp_session_finalize (GObject *object)
     g_dbus_connection_signal_unsubscribe (session->portal->bus, session->signal_id);
 
   g_clear_object (&session->portal);
-  g_free (session->restore_token);
-  g_free (session->id);
+  g_clear_pointer (&session->restore_token, g_free);
+  g_clear_pointer (&session->id, g_free);
   g_clear_pointer (&session->streams, g_variant_unref);
 
   G_OBJECT_CLASS (xdp_session_parent_class)->finalize (object);

--- a/libportal/session.c
+++ b/libportal/session.c
@@ -129,6 +129,22 @@ _xdp_session_new (XdpPortal *portal,
   return session;
 }
 
+const char *
+_xdp_session_get_id (XdpSession *session)
+{
+  g_return_val_if_fail (XDP_IS_SESSION (session), NULL);
+
+  return session->id;
+}
+
+XdpPortal *
+_xdp_session_get_portal (XdpSession *session)
+{
+  g_return_val_if_fail (XDP_IS_SESSION (session), NULL);
+
+  return session->portal;
+}
+
 /**
  * xdp_session_get_session_type:
  * @session: an [class@Session]
@@ -212,6 +228,14 @@ _xdp_session_set_devices (XdpSession *session,
   session->devices = devices;
 }
 
+XdpDeviceType
+_xdp_session_get_devices (XdpSession *session)
+{
+  g_return_val_if_fail (XDP_IS_SESSION (session), XDP_DEVICE_NONE);
+
+  return session->devices;
+}
+
 /**
  * xdp_session_get_streams:
  * @session: a [class@Session]
@@ -255,4 +279,35 @@ _xdp_session_set_streams (XdpSession *session,
   session->streams = streams;
   if (session->streams)
     g_variant_ref (session->streams);
+}
+
+void
+_xdp_session_set_persist_mode (XdpSession *session,
+                               XdpPersistMode persist_mode)
+{
+  session->persist_mode = persist_mode;
+}
+
+XdpPersistMode
+_xdp_session_get_persist_mode (XdpSession *session)
+{
+  g_return_val_if_fail (XDP_IS_SESSION (session), XDP_PERSIST_MODE_NONE);
+
+  return session->persist_mode;
+}
+
+void
+_xdp_session_set_restore_token (XdpSession *session,
+                                char *restore_token)
+{
+  g_clear_pointer (&session->restore_token, g_free);
+  session->restore_token = restore_token;
+}
+
+const char *
+_xdp_session_get_restore_token (XdpSession *session)
+{
+  g_return_val_if_fail (XDP_IS_SESSION (session), NULL);
+
+  return session->restore_token;
 }

--- a/libportal/session.h
+++ b/libportal/session.h
@@ -26,7 +26,7 @@ G_BEGIN_DECLS
 #define XDP_TYPE_SESSION (xdp_session_get_type ())
 
 XDP_PUBLIC
-G_DECLARE_FINAL_TYPE (XdpSession, xdp_session, XDP, SESSION, GObject)
+G_DECLARE_DERIVABLE_TYPE (XdpSession, xdp_session, XDP, SESSION, GObject)
 
 /**
  * XdpSessionType:

--- a/libportal/session.h
+++ b/libportal/session.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2018, Matthias Clasen
+ *
+ * This file is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, version 3.0 of the
+ * License.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-only
+ */
+
+#pragma once
+
+#include <libportal/types.h>
+
+G_BEGIN_DECLS
+
+#define XDP_TYPE_SESSION (xdp_session_get_type ())
+
+XDP_PUBLIC
+G_DECLARE_FINAL_TYPE (XdpSession, xdp_session, XDP, SESSION, GObject)
+
+/**
+ * XdpSessionType:
+ * @XDP_SESSION_SCREENCAST: a screencast session.
+ * @XDP_SESSION_REMOTE_DESKTOP: a remote desktop session.
+ *
+ * The type of a session.
+ */
+typedef enum {
+  XDP_SESSION_SCREENCAST,
+  XDP_SESSION_REMOTE_DESKTOP,
+} XdpSessionType;
+
+/**
+ * XdpSessionState:
+ * @XDP_SESSION_INITIAL: the session has not been started.
+ * @XDP_SESSION_ACTIVE: the session is active.
+ * @XDP_SESSION_CLOSED: the session is no longer active.
+ *
+ * The state of a session.
+ */
+typedef enum {
+  XDP_SESSION_INITIAL,
+  XDP_SESSION_ACTIVE,
+  XDP_SESSION_CLOSED
+} XdpSessionState;
+
+XDP_PUBLIC
+void            xdp_session_close             (XdpSession *session);
+
+XDP_PUBLIC
+XdpSessionType  xdp_session_get_session_type  (XdpSession *session);
+
+XDP_PUBLIC
+XdpSessionState xdp_session_get_session_state (XdpSession *session);
+
+G_END_DECLS

--- a/tests/pyportaltest/templates/__init__.py
+++ b/tests/pyportaltest/templates/__init__.py
@@ -42,6 +42,7 @@ class Request:
             props={},
         )
         self.mock.AddMethod("", "Close", "", "", "self.RemoveObject(self.path)")
+        logger.debug(f"Request created at {self.handle}")
 
     def respond(self, response: Response, delay: int = 0):
         def respond():
@@ -80,6 +81,7 @@ class Session:
             props={},
         )
         self.mock.AddMethod("", "Close", "", "", "self.RemoveObject(self.path)")
+        logger.debug(f"Session created at {self.handle}")
 
     def close(self, details: ASVType, delay: int = 0):
         def respond():

--- a/tests/pyportaltest/templates/remotedesktop.py
+++ b/tests/pyportaltest/templates/remotedesktop.py
@@ -2,7 +2,7 @@
 #
 # This file is formatted with Python Black
 
-from pyportaltest.templates import Request, Response, ASVType
+from pyportaltest.templates import Request, Response, Session, ASVType
 from typing import Dict, List, Tuple, Iterator
 from itertools import count
 
@@ -42,6 +42,8 @@ def load(mock, parameters=None):
         ),
     )
 
+    mock.sessions: Dict[str, Session] = {}
+
 
 @dbus.service.method(
     MAIN_IFACE,
@@ -53,6 +55,9 @@ def CreateSession(self, options, sender):
     try:
         logger.debug(f"CreateSession: {options}")
         request = Request(bus_name=self.bus_name, sender=sender, options=options)
+
+        session = Session(bus_name=self.bus_name, sender=sender, options=options)
+        self.sessions[session.handle] = session
 
         response = Response(self.response, {})
 

--- a/tests/pyportaltest/templates/screencast.py
+++ b/tests/pyportaltest/templates/screencast.py
@@ -2,7 +2,7 @@
 #
 # This file is formatted with Python Black
 
-from pyportaltest.templates import Request, Response, ASVType
+from pyportaltest.templates import Request, Response, Session, ASVType
 from typing import Dict, List, Tuple, Iterator
 from itertools import count
 
@@ -49,6 +49,8 @@ def load(mock, parameters=None):
         ),
     )
 
+    mock.sessions: Dict[str, Session] = {}
+
 
 @dbus.service.method(
     MAIN_IFACE,
@@ -60,6 +62,9 @@ def CreateSession(self, options, sender):
     try:
         logger.debug(f"CreateSession: {options}")
         request = Request(bus_name=self.bus_name, sender=sender, options=options)
+
+        session = Session(bus_name=self.bus_name, sender=sender, options=options)
+        self.sessions[session.handle] = session
 
         response = Response(self.response, {})
 

--- a/tests/pyportaltest/test_screencast.py
+++ b/tests/pyportaltest/test_screencast.py
@@ -27,6 +27,7 @@ class SessionCreationFailed(Exception):
 
 class SessionSetup(NamedTuple):
     session: Xdp.Session
+    session_handle_token: str
     pw_fd: TextIO
 
 
@@ -81,6 +82,16 @@ class TestScreenCast(PortalTest):
         if session_error is not None:
             raise SessionCreationFailed(session_error)
 
+        # Extract our expected session id. This isn't available from
+        # XdpSession so we need to go around it. We can't easily get the
+        # sender id so the full path is hard. Let's just extract the token and
+        # pretend that's good enough.
+        method_calls = self.mock_interface.GetMethodCalls("CreateSession")
+        assert len(method_calls) >= 1
+        _, args = method_calls.pop()  # Assume the latest has our session
+        (options,) = args
+        session_handle = options["session_handle_token"]
+
         assert session.get_session_type() == Xdp.SessionType.SCREENCAST
 
         # open the PW remote by default since we need it anyway for Start()
@@ -90,6 +101,7 @@ class TestScreenCast(PortalTest):
 
         return SessionSetup(
             session=session,
+            session_handle_token=session_handle,
             pw_fd=pw_fd,
         )
 
@@ -268,3 +280,31 @@ class TestScreenCast(PortalTest):
         session_handle, parent_window, options = args
         assert parent_window == ""
         assert list(options.keys()) == ["handle_token"]
+
+    def test_close_session(self):
+        """
+        Ensure that closing our session explicitly closes the session on DBus
+        """
+        setup = self.create_session()
+        session = setup.session
+
+        was_closed = False
+
+        def method_called(method_name, method_args, path):
+            nonlocal was_closed
+
+            if method_name == "Close" and path.endswith(setup.session_handle_token):
+                was_closed = True
+                self.mainloop.quit()
+
+        bus = self.get_dbus()
+        bus.add_signal_receiver(
+            handler_function=method_called,
+            signal_name="MethodCalled",
+            dbus_interface="org.freedesktop.DBus.Mock",
+            path_keyword="path",
+        )
+
+        session.close()
+        self.mainloop.run()
+        assert was_closed is True


### PR DESCRIPTION
`XdpSession` is currently a mixed struct, comprising of both the bits required for a Session in general and the bits required for a ScreenCast session and/or a RemoteDesktop Session (the latter is *usually* a ScreenCast session too but does not have to be).

This works though only because we effectively only have one real subtype. With InputCapture using sessions as well we're getting namespace crowding and collisions. Fix this by switching `XdpSession` to be a derivable object and then subclass `XdpScreenCastSession` from it and then `XdpRemoteDesktopSession` from that.

API-wise nothing changes, the returned objects are now of the right subclass but the API itself remains unchanged. Ideally we could deprecate the current ones and switch the others to "type-safe" APIs but that's mostly busywork and I can't come up with a non-clashing nice enough name for the `create_...` calls.

cc @jadahl