### PR TITLE
Up the warning level and fix the resulting warnings

### DIFF
--- a/libportal/notification.c
+++ b/libportal/notification.c
@@ -32,7 +32,6 @@ action_invoked (GDBusConnection *bus,
                 gpointer data)
 {
   XdpPortal *portal = data;
-  g_autoptr(GVariant) info = NULL;
   const char *id;
   const char *action;
   g_autoptr(GVariant) parameter = NULL;

--- a/libportal/portal.c
+++ b/libportal/portal.c
@@ -339,9 +339,10 @@ _xdp_parse_cgroup_file (FILE *f, gboolean *is_snap)
 
       /* Only consider the freezer, systemd group or unified cgroup
        * hierarchies */
-      if ((!strcmp (controller, "freezer:") != 0 ||
-           !strcmp (controller, "name=systemd:") != 0 ||
-           !strcmp (controller, ":") != 0) &&
+      if (controller != NULL &&
+          (g_str_equal (controller, "freezer:") ||
+           g_str_equal (controller, "name=systemd:") ||
+           g_str_equal (controller, ":")) &&
           strstr (cgroup, "/snap.") != NULL)
         {
           *is_snap = TRUE;

--- a/libportal/spawn.c
+++ b/libportal/spawn.c
@@ -131,6 +131,8 @@ do_spawn (SpawnCall *call)
 
   ensure_spawn_exited_connection (call->portal);
 
+  g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
+
   g_variant_builder_init (&fds_builder, G_VARIANT_TYPE ("a{uh}"));
   if (call->n_fds > 0)
     {

--- a/libportal/updates.c
+++ b/libportal/updates.c
@@ -168,7 +168,6 @@ create_monitor (CreateMonitorCall *call)
 {
   GVariantBuilder options;
   g_autofree char *token = NULL;
-  g_autofree char *session_token = NULL;
   GCancellable *cancellable;
 
   if (call->portal->update_monitor_handle)

--- a/meson.build
+++ b/meson.build
@@ -1,8 +1,14 @@
 project('libportal','c',
         version: '0.6',
+        default_options: ['warning_level=2'],
         meson_version: '>= 0.49.0')
 
 cc = meson.get_compiler('c')
+cflags = [
+  '-Wno-unused-parameter',
+  '-Wno-missing-field-initializers',
+]
+add_project_arguments(cc.get_supported_arguments(cflags), language: 'c')
 
 gnome = import('gnome')
 pkgconfig = import('pkgconfig')

--- a/portal-test/gtk3/portal-test-win.c
+++ b/portal-test/gtk3/portal-test-win.c
@@ -1106,7 +1106,7 @@ inhibit_changed (GtkToggleButton *button, PortalTestWin *win)
       xdp_portal_session_inhibit (win->portal,
                                   parent,
                                   "Portal Testing",
-                                  win->inhibit_flags,
+                                  (XdpInhibitFlags)win->inhibit_flags,
                                   NULL,
                                   inhibit_finished,
                                   win);

--- a/portal-test/gtk3/portal-test-win.c
+++ b/portal-test/gtk3/portal-test-win.c
@@ -526,7 +526,6 @@ taken (GObject *source,
 {
   PortalTestWin *win = data;
   g_autofree char *uri = NULL;
-  g_autoptr(GdkPixbuf) pixbuf = NULL;
   g_autoptr(GError) error = NULL;
 
   uri = xdp_portal_take_screenshot_finish (win->portal, result, &error);


### PR DESCRIPTION
cc @mwleeds for the cgroup hierarchies, `!strcmp() != 0` was sufficiently confusing that I'm going to punt this to you :smile: but based on the comment above, `g_str_equal()` should be the correct replacement.
