### PR TITLE
meson: default the backends list to 'auto'

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Check out libportal
         uses: actions/checkout@v1
       - name: Configure libportal
-        run: meson setup --prefix=/usr _build -Dbackends=gtk3 -Ddocs=false
+        run: meson setup --prefix=/usr _build -Dbackend-gtk3=enabled -Ddocs=false
       - name: Build libportal
         run: ninja -C_build
 
@@ -43,7 +43,7 @@ jobs:
       - name: Check out libportal
         uses: actions/checkout@v1
       - name: Configure libportal
-        run: meson setup --prefix=/usr _build -Dbackends=gtk3,gtk4
+        run: meson setup --prefix=/usr _build -Dbackend-gtk3=enabled -Dbackend-gtk4=enabled
       - name: Build libportal
         run: ninja -C_build
 
@@ -62,7 +62,7 @@ jobs:
       - name: Check out libportal
         uses: actions/checkout@v1
       - name: Configure libportal
-        run: meson setup --prefix=/usr _build -Dbackends=gtk3,gtk4
+        run: meson setup --prefix=/usr _build -Dbackend-gtk3=enabled -Dbackend-gtk4=enabled
       - name: Build libportal
         run: ninja -C_build
       - name: Deploy Docs

--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ For subsequent builds, you only need to use the `ninja -C _build` command.
 ### Passing options
 
 libportal includes [Meson build options][2] for components that can optionally
-be built. After first running `meson _build`, you can view the available options
-with:
+be built. Run `meson configure` to see all available options or,
+after first running `meson _build`, view available options and their current
+values with:
 
 ```
 meson configure _build

--- a/build-aux/org.gnome.PortalTest.Gtk3.json
+++ b/build-aux/org.gnome.PortalTest.Gtk3.json
@@ -31,7 +31,7 @@
             "buildsystem": "meson",
             "builddir": true,
             "config-opts": [
-              "-Dbackends=gtk3",
+              "-Dbackend-gtk3=enabled",
               "-Dportal-tests=true",
               "-Ddocs=false"
             ],

--- a/build-aux/org.gnome.PortalTest.Gtk4.json
+++ b/build-aux/org.gnome.PortalTest.Gtk4.json
@@ -16,7 +16,7 @@
             "buildsystem": "meson",
             "builddir": true,
             "config-opts": [
-              "-Dbackends=gtk4",
+              "-Dbackend-gtk4=enabled",
               "-Dportal-tests=true",
               "-Ddocs=false"
             ],

--- a/build-aux/org.gnome.PortalTest.Qt5.json
+++ b/build-aux/org.gnome.PortalTest.Qt5.json
@@ -15,7 +15,7 @@
             "buildsystem": "meson",
             "builddir": true,
             "config-opts": [
-              "-Dbackends=qt5",
+              "-Dbackend-qt5=enabled",
               "-Dportal-tests=true",
               "-Dintrospection=false",
               "-Dvapi=false",

--- a/libportal/meson.build
+++ b/libportal/meson.build
@@ -109,12 +109,14 @@ if introspection
   endif
 endif
 
+enabled_backends = []
+
 ########
 # GTK3 #
 ########
 
-if 'gtk3' in backends
-  gtk3_dep = dependency('gtk+-3.0')
+gtk3_dep = dependency('gtk+-3.0', required: get_option('backend-gtk3'))
+if gtk3_dep.found()
   gtk3_headers = ['portal-gtk3.h']
   gtk3_sources = ['portal-gtk3.c']
 
@@ -164,14 +166,15 @@ if 'gtk3' in backends
       )
     endif
   endif
+  enabled_backends += ['gtk3']
 endif
 
 ########
 # GTK4 #
 ########
 
-if 'gtk4' in backends
-  gtk4_dep = dependency('gtk4')
+gtk4_dep = dependency('gtk4', required: get_option('backend-gtk4'))
+if gtk4_dep.found()
   gtk4_headers = ['portal-gtk4.h']
   gtk4_sources = ['portal-gtk4.c']
 
@@ -222,16 +225,17 @@ if 'gtk4' in backends
       )
     endif
   endif
+  enabled_backends += ['gtk4']
 endif
 
 ########
 # Qt 5 #
 ########
 
-if 'qt5' in backends
-  add_languages('cpp', required : true)
+have_cpp = add_languages('cpp', required: get_option('backend-qt5'))
+qt5_dep = dependency('qt5', modules: ['Core', 'Gui', 'X11Extras', 'Widgets'], required: get_option('backend-qt5'))
 
-  qt5_dep = dependency('qt5', modules: ['Core', 'Gui', 'X11Extras', 'Widgets'])
+if have_cpp and qt5_dep.found()
   qt5_headers = ['portal-qt5.h']
   qt5_sources = ['portal-qt5.cpp']
 
@@ -257,4 +261,9 @@ if 'qt5' in backends
     dependencies: [libportal_dep, qt5_dep],
     link_with: libportal_qt5,
   )
+  enabled_backends += ['qt5']
+endif
+
+if meson.version().version_compare('>= 0.54.0')
+  summary({'enabled backends': enabled_backends}, section: 'Backends', list_sep: ',')
 endif

--- a/meson.build
+++ b/meson.build
@@ -34,7 +34,6 @@ endforeach
 
 configure_file(output : 'config.h', configuration : conf)
 
-backends = get_option('backends')
 introspection = get_option('introspection')
 vapi = get_option('vapi')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,5 +1,9 @@
-option('backends', type: 'array', choices: ['gtk3', 'gtk4', 'qt5'], value: ['gtk3', 'gtk4', 'qt5'],
-  description : 'A list of portal backends to build')
+option('backend-gtk3', type: 'feature', value: 'auto',
+  description: 'Build the GTK3 portal backend')
+option('backend-gtk4', type: 'feature', value: 'auto',
+  description: 'Build the GTK4 portal backend')
+option('backend-qt5', type: 'feature', value: 'auto',
+  description: 'Build the Qt5 portal backend')
 option('portal-tests', type: 'boolean', value: false,
   description : 'Build portal tests of each backend')
 option('introspection', type: 'boolean', value: true,

--- a/portal-test/meson.build
+++ b/portal-test/meson.build
@@ -1,3 +1,3 @@
-foreach backend : backends
+foreach backend : enabled_backends
   subdir(backend)
 endforeach

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,4 +1,4 @@
-if 'qt5' in backends
+if 'qt5' in enabled_backends
   subdir('qt5')
 endif
 


### PR DESCRIPTION
This changes the 'backends' option to the special string 'auto' - all
backends become optional by default and are built if the dependencies
are available.

If need be this can be combined with explicitly listing a backend, so
backends=auto,gtk3 will require the GTK3 backend and optionally build
the Qt5 and GTK4 backends. A summary is printed to list the actually
enabled backends and a warning where no backends are enabled at all.

This makes life easier for new users since the majority of them will not
have GTK3, GTK4 and Qt5 headers installed by default and thus are almost
guaranteed to run into a meson error on first configure.

Fixes https://github.com/flatpak/libportal/issues/94