### PR TITLE
portal: fix build on darwin

### DIFF
--- a/libportal/portal.c
+++ b/libportal/portal.c
@@ -27,7 +27,11 @@
 #include <string.h>
 #include <fcntl.h>
 #include <errno.h>
+#ifdef __APPLE__
+#include <sys/mount.h>
+#else
 #include <sys/vfs.h>
+#endif
 #include <stdio.h>
 
 /**


### PR DESCRIPTION
This PR fixes a regression on building libportal on macOS, introduced by #63.

Tested via CI in NixOS/nixpkgs#184309.