### PR TITLE
Draft: Detangle Session creation from the RemoteDesktop/ScreenCast portals

### DIFF
--- a/libportal/meson.build
+++ b/libportal/meson.build
@@ -19,6 +19,7 @@ headers = [
   'print.h',
   'remote.h',
   'screenshot.h',
+  'session.h',
   'spawn.h',
   'trash.h',
   'types.h',

--- a/libportal/remote.h
+++ b/libportal/remote.h
@@ -20,13 +20,23 @@
 #pragma once
 
 #include <libportal/types.h>
+#include <libportal/session.h>
 
 G_BEGIN_DECLS
 
-#define XDP_TYPE_SESSION (xdp_session_get_type ())
-
-XDP_PUBLIC
-G_DECLARE_FINAL_TYPE (XdpSession, xdp_session, XDP, SESSION, GObject)
+/**
+ * XdpSessionState:
+ * @XDP_SESSION_INITIAL: the session has not been started.
+ * @XDP_SESSION_ACTIVE: the session is active.
+ * @XDP_SESSION_CLOSED: the session is no longer active.
+ *
+ * The state of a session.
+ */
+typedef enum {
+  XDP_SESSION_INITIAL,
+  XDP_SESSION_ACTIVE,
+  XDP_SESSION_CLOSED
+} XdpSessionState;
 
 /**
  * XdpOutputType:
@@ -59,32 +69,6 @@ typedef enum {
   XDP_DEVICE_POINTER     = 1 << 1,
   XDP_DEVICE_TOUCHSCREEN = 1 << 2
 } XdpDeviceType;
-
-/**
- * XdpSessionType:
- * @XDP_SESSION_SCREENCAST: a screencast session.
- * @XDP_SESSION_REMOTE_DESKTOP: a remote desktop session.
- *
- * The type of a session.
- */
-typedef enum {
-  XDP_SESSION_SCREENCAST,
-  XDP_SESSION_REMOTE_DESKTOP
-} XdpSessionType;
-
-/**
- * XdpSessionState:
- * @XDP_SESSION_INITIAL: the session has not been started.
- * @XDP_SESSION_ACTIVE: the session is active.
- * @XDP_SESSION_CLOSED: the session is no longer active.
- *
- * The state of a session.
- */
-typedef enum {
-  XDP_SESSION_INITIAL,
-  XDP_SESSION_ACTIVE,
-  XDP_SESSION_CLOSED
-} XdpSessionState;
 
 /**
  * XdpScreencastFlags:
@@ -170,6 +154,9 @@ XdpSession *xdp_portal_create_remote_desktop_session_finish (XdpPortal          
                                                              GError                **error);
 
 XDP_PUBLIC
+XdpSessionState xdp_session_get_session_state (XdpSession *session);
+
+XDP_PUBLIC
 void        xdp_session_start                (XdpSession           *session,
                                               XdpParent            *parent,
                                               GCancellable         *cancellable,
@@ -182,16 +169,7 @@ gboolean    xdp_session_start_finish         (XdpSession           *session,
                                               GError              **error);
 
 XDP_PUBLIC
-void        xdp_session_close                (XdpSession           *session);
-
-XDP_PUBLIC
 int         xdp_session_open_pipewire_remote (XdpSession           *session);
-
-XDP_PUBLIC
-XdpSessionType  xdp_session_get_session_type  (XdpSession *session);
-
-XDP_PUBLIC
-XdpSessionState xdp_session_get_session_state (XdpSession *session);
 
 XDP_PUBLIC
 XdpDeviceType   xdp_session_get_devices       (XdpSession *session);

--- a/libportal/remote.h
+++ b/libportal/remote.h
@@ -162,6 +162,90 @@ typedef enum {
 } XdpKeyState;
 
 XDP_PUBLIC
+void        xdp_screencast_create_session           (XdpSession           *session,
+                                                     XdpOutputType         outputs,
+                                                     XdpScreencastFlags    flags,
+                                                     XdpCursorMode         cursor_mode,
+                                                     XdpPersistMode        persist_mode,
+                                                     const char           *restore_token,
+                                                     GCancellable         *cancellable,
+                                                     GAsyncReadyCallback   callback,
+                                                     gpointer              data);
+
+gboolean    xdp_screencast_create_session_finish    (XdpSession           *session,
+                                                     GAsyncResult         *result,
+                                                     GError              **error);
+
+
+XDP_PUBLIC
+void        xdp_remote_desktop_create_session       (XdpSession             *session,
+                                                     XdpDeviceType           devices,
+                                                     XdpOutputType           outputs,
+                                                     XdpRemoteDesktopFlags   flags,
+                                                     XdpCursorMode           cursor_mode,
+                                                     GCancellable           *cancellable,
+                                                     GAsyncReadyCallback     callback,
+                                                     gpointer                data);
+
+XDP_PUBLIC
+gboolean    xdp_remote_desktop_create_session_finish(XdpSession             *session,
+                                                     GAsyncResult           *result,
+                                                     GError                **error);
+
+XDP_PUBLIC
+void        xdp_remote_desktop_start                (XdpSession           *session,
+                                                     XdpParent            *parent,
+                                                     GCancellable         *cancellable,
+                                                     GAsyncReadyCallback   callback,
+                                                     gpointer              data);
+
+XDP_PUBLIC
+gboolean    xdp_remote_desktop_start_finish         (XdpSession           *session,
+                                                     GAsyncResult         *result,
+                                                     GError              **error);
+
+XDP_PUBLIC
+void        xdp_screeencast_start                   (XdpSession           *session,
+                                                     XdpParent            *parent,
+                                                     GCancellable         *cancellable,
+                                                     GAsyncReadyCallback   callback,
+                                                     gpointer              data);
+
+XDP_PUBLIC
+gboolean    xdp_screencast_start_finish             (XdpSession           *session,
+                                                     GAsyncResult         *result,
+                                                     GError              **error);
+
+XDP_PUBLIC
+int         xdp_screencast_open_pipewire_remote     (XdpSession            *session);
+
+XDP_PUBLIC
+XdpDeviceType   xdp_remote_desktop_get_devices      (XdpSession            *session);
+
+XDP_PUBLIC
+GVariant *  xdp_screencast_get_streams              (XdpSession             *session);
+
+XDP_PUBLIC
+void        xdp_remote_desktop_pointer_motion       (XdpSession             *session,
+                                                     double                  dx,
+                                                     double                  dy);
+
+XDP_PUBLIC
+XdpPersistMode  xdp_screencast_get_persist_mode     (XdpSession             *session);
+
+XDP_PUBLIC
+char           *xdp_screencast_get_restore_token    (XdpSession             *session);
+
+XDP_PUBLIC
+XdpSessionState xdp_screencast_get_session_state    (XdpSession             *session);
+
+XDP_PUBLIC
+XdpSessionState xdp_remote_desktop_get_session_state(XdpSession             *session);
+
+/* Deprecated API below */
+
+G_DEPRECATED_FOR (xdp_screencast_create_session)
+XDP_PUBLIC
 void        xdp_portal_create_screencast_session            (XdpPortal            *portal,
                                                              XdpOutputType         outputs,
                                                              XdpScreencastFlags    flags,
@@ -172,10 +256,12 @@ void        xdp_portal_create_screencast_session            (XdpPortal          
                                                              GAsyncReadyCallback   callback,
                                                              gpointer              data);
 
+G_DEPRECATED_FOR (xdp_screencast_create_session_finish)
 XDP_PUBLIC
 XdpSession *xdp_portal_create_screencast_session_finish     (XdpPortal            *portal,
                                                              GAsyncResult         *result,
                                                              GError              **error);
+G_DEPRECATED_FOR (xdp_remote_desktop_create_session)
 XDP_PUBLIC
 void        xdp_portal_create_remote_desktop_session        (XdpPortal              *portal,
                                                              XdpDeviceType           devices,
@@ -186,14 +272,17 @@ void        xdp_portal_create_remote_desktop_session        (XdpPortal          
                                                              GAsyncReadyCallback     callback,
                                                              gpointer                data);
 
+G_DEPRECATED_FOR (xdp_remote_desktop_create_session_finish)
 XDP_PUBLIC
 XdpSession *xdp_portal_create_remote_desktop_session_finish (XdpPortal              *portal,
                                                              GAsyncResult           *result,
                                                              GError                **error);
 
+G_DEPRECATED_FOR (xdp_screencast_get_session_state)
 XDP_PUBLIC
 XdpSessionState xdp_session_get_session_state (XdpSession *session);
 
+G_DEPRECATED_FOR (xdp_remote_desktop_start)
 XDP_PUBLIC
 void        xdp_session_start                (XdpSession           *session,
                                               XdpParent            *parent,
@@ -201,20 +290,25 @@ void        xdp_session_start                (XdpSession           *session,
                                               GAsyncReadyCallback   callback,
                                               gpointer              data);
 
+G_DEPRECATED_FOR (xdp_remote_desktop_start_finish)
 XDP_PUBLIC
 gboolean    xdp_session_start_finish         (XdpSession           *session,
                                               GAsyncResult         *result,
                                               GError              **error);
 
+G_DEPRECATED_FOR (xdp_screencast_open_pipewire_remote)
 XDP_PUBLIC
 int         xdp_session_open_pipewire_remote (XdpSession           *session);
 
+G_DEPRECATED_FOR (xdp_remote_desktop_get_devices)
 XDP_PUBLIC
 XdpDeviceType   xdp_session_get_devices       (XdpSession *session);
 
+G_DEPRECATED_FOR (xdp_screencast_get_streams)
 XDP_PUBLIC
 GVariant *      xdp_session_get_streams       (XdpSession *session);
 
+G_DEPRECATED_FOR (xdp_remote_desktop_pointer_motion)
 XDP_PUBLIC
 void      xdp_session_pointer_motion    (XdpSession *session,
                                          double      dx,
@@ -267,9 +361,11 @@ void      xdp_session_touch_up       (XdpSession *session,
                                       guint       slot);
 
 
+G_DEPRECATED_FOR (xdp_screencast_get_persist_mode)
 XDP_PUBLIC
 XdpPersistMode  xdp_session_get_persist_mode  (XdpSession *session);
 
+G_DEPRECATED_FOR (xdp_screencast_get_restore_token)
 XDP_PUBLIC
 char           *xdp_session_get_restore_token (XdpSession *session);
 

--- a/libportal/remote.h
+++ b/libportal/remote.h
@@ -110,6 +110,57 @@ typedef enum {
   XDP_PERSIST_MODE_PERSISTENT,
 } XdpPersistMode;
 
+/**
+ * XdpRemoteDesktopFlags:
+ * @XDP_REMOTE_DESKTOP_FLAG_NONE: No options
+ * @XDP_REMOTE_DESKTOP_FLAG_MULTIPLE: allow opening multiple streams
+ *
+ * Options for starting remote desktop sessions.
+ */
+typedef enum {
+  XDP_REMOTE_DESKTOP_FLAG_NONE     = 0,
+  XDP_REMOTE_DESKTOP_FLAG_MULTIPLE = 1 << 0
+} XdpRemoteDesktopFlags;
+
+/**
+ * XdpButtonState:
+ * @XDP_BUTTON_RELEASED: the button is down
+ * @XDP_BUTTON_PRESSED: the button is up
+ *
+ * The XdpButtonState enumeration is used to describe
+ * the state of buttons.
+ */
+typedef enum {
+  XDP_BUTTON_RELEASED = 0,
+  XDP_BUTTON_PRESSED = 1
+} XdpButtonState;
+
+/**
+ * XdpDiscreteAxis:
+ * @XDP_AXIS_HORIZONTAL_SCROLL: the horizontal scroll axis
+ * @XDP_AXIS_VERTICAL_SCROLL: the horizontal scroll axis
+ *
+ * The `XdpDiscreteAxis` enumeration is used to describe
+ * the discrete scroll axes.
+ */
+typedef enum {
+  XDP_AXIS_HORIZONTAL_SCROLL = 0,
+  XDP_AXIS_VERTICAL_SCROLL   = 1
+} XdpDiscreteAxis;
+
+/**
+ * XdpKeyState:
+ * @XDP_KEY_RELEASED: the key is down
+ * @XDP_KEY_PRESSED: the key is up
+ *
+ * The `XdpKeyState` enumeration is used to describe
+ * the state of keys.
+ */
+typedef enum {
+  XDP_KEY_RELEASED = 0,
+  XDP_KEY_PRESSED = 1
+} XdpKeyState;
+
 XDP_PUBLIC
 void        xdp_portal_create_screencast_session            (XdpPortal            *portal,
                                                              XdpOutputType         outputs,
@@ -125,19 +176,6 @@ XDP_PUBLIC
 XdpSession *xdp_portal_create_screencast_session_finish     (XdpPortal            *portal,
                                                              GAsyncResult         *result,
                                                              GError              **error);
-
-/**
- * XdpRemoteDesktopFlags:
- * @XDP_REMOTE_DESKTOP_FLAG_NONE: No options
- * @XDP_REMOTE_DESKTOP_FLAG_MULTIPLE: allow opening multiple streams
- *
- * Options for starting remote desktop sessions.
- */
-typedef enum {
-  XDP_REMOTE_DESKTOP_FLAG_NONE     = 0,
-  XDP_REMOTE_DESKTOP_FLAG_MULTIPLE = 1 << 0
-} XdpRemoteDesktopFlags;
-
 XDP_PUBLIC
 void        xdp_portal_create_remote_desktop_session        (XdpPortal              *portal,
                                                              XdpDeviceType           devices,
@@ -187,18 +225,6 @@ void      xdp_session_pointer_position  (XdpSession *session,
                                          guint       stream,
                                          double      x,
                                          double      y);
-/**
- * XdpButtonState:
- * @XDP_BUTTON_RELEASED: the button is down
- * @XDP_BUTTON_PRESSED: the button is up
- *
- * The XdpButtonState enumeration is used to describe
- * the state of buttons.
- */
-typedef enum {
-  XDP_BUTTON_RELEASED = 0,
-  XDP_BUTTON_PRESSED = 1
-} XdpButtonState;
 
 XDP_PUBLIC
 void      xdp_session_pointer_button (XdpSession     *session,
@@ -211,36 +237,10 @@ void      xdp_session_pointer_axis   (XdpSession     *session,
                                       double          dx,
                                       double          dy);
 
-/**
- * XdpDiscreteAxis:
- * @XDP_AXIS_HORIZONTAL_SCROLL: the horizontal scroll axis
- * @XDP_AXIS_VERTICAL_SCROLL: the horizontal scroll axis
- *
- * The `XdpDiscreteAxis` enumeration is used to describe
- * the discrete scroll axes.
- */
-typedef enum {
-  XDP_AXIS_HORIZONTAL_SCROLL = 0,
-  XDP_AXIS_VERTICAL_SCROLL   = 1
-} XdpDiscreteAxis;
-
 XDP_PUBLIC
 void      xdp_session_pointer_axis_discrete (XdpSession *session,
                                              XdpDiscreteAxis  axis,
                                              int              steps);
-
-/**
- * XdpKeyState:
- * @XDP_KEY_RELEASED: the key is down
- * @XDP_KEY_PRESSED: the key is up
- *
- * The `XdpKeyState` enumeration is used to describe
- * the state of keys.
- */
-typedef enum {
-  XDP_KEY_RELEASED = 0,
-  XDP_KEY_PRESSED = 1
-} XdpKeyState;
 
 XDP_PUBLIC
 void      xdp_session_keyboard_key   (XdpSession *session,

--- a/libportal/remote.h
+++ b/libportal/remote.h
@@ -50,7 +50,7 @@ typedef enum {
  * @XDP_DEVICE_KEYBOARD: control the keyboard.
  * @XDP_DEVICE_POINTER: control the pointer.
  * @XDP_DEVICE_TOUCHSCREEN: control the touchscreen.
- * 
+ *
  * Flags to specify what input devices to control for a remote desktop session.
  */
 typedef enum {
@@ -242,8 +242,8 @@ void      xdp_session_pointer_axis   (XdpSession     *session,
  * the discrete scroll axes.
  */
 typedef enum {
-  XDP_AXIS_HORIZONTAL_SCROLL = 0, 
-  XDP_AXIS_VERTICAL_SCROLL   = 1 
+  XDP_AXIS_HORIZONTAL_SCROLL = 0,
+  XDP_AXIS_VERTICAL_SCROLL   = 1
 } XdpDiscreteAxis;
 
 XDP_PUBLIC
@@ -266,7 +266,7 @@ typedef enum {
 
 XDP_PUBLIC
 void      xdp_session_keyboard_key   (XdpSession *session,
-                                      gboolean    keysym, 
+                                      gboolean    keysym,
                                       int         key,
                                       XdpKeyState state);
 

--- a/libportal/session.c
+++ b/libportal/session.c
@@ -55,8 +55,8 @@ xdp_session_finalize (GObject *object)
     g_dbus_connection_signal_unsubscribe (session->portal->bus, session->signal_id);
 
   g_clear_object (&session->portal);
-  g_free (session->restore_token);
-  g_free (session->id);
+  g_clear_pointer (&session->restore_token, g_free);
+  g_clear_pointer (&session->id, g_free);
   g_clear_pointer (&session->streams, g_variant_unref);
 
   G_OBJECT_CLASS (xdp_session_parent_class)->finalize (object);

--- a/libportal/session.h
+++ b/libportal/session.h
@@ -19,24 +19,31 @@
 
 #pragma once
 
-#include <libportal/portal-enums.h>
-#include <libportal/account.h>
-#include <libportal/background.h>
-#include <libportal/camera.h>
-#include <libportal/dynamic-launcher.h>
-#include <libportal/email.h>
-#include <libportal/filechooser.h>
-#include <libportal/inhibit.h>
-#include <libportal/location.h>
-#include <libportal/notification.h>
-#include <libportal/openuri.h>
-#include <libportal/parent.h>
-#include <libportal/print.h>
-#include <libportal/remote.h>
-#include <libportal/screenshot.h>
-#include <libportal/session.h>
-#include <libportal/spawn.h>
-#include <libportal/trash.h>
 #include <libportal/types.h>
-#include <libportal/updates.h>
-#include <libportal/wallpaper.h>
+
+G_BEGIN_DECLS
+
+#define XDP_TYPE_SESSION (xdp_session_get_type ())
+
+XDP_PUBLIC
+G_DECLARE_FINAL_TYPE (XdpSession, xdp_session, XDP, SESSION, GObject)
+
+/**
+ * XdpSessionType:
+ * @XDP_SESSION_SCREENCAST: a screencast session.
+ * @XDP_SESSION_REMOTE_DESKTOP: a remote desktop session.
+ *
+ * The type of a session.
+ */
+typedef enum {
+  XDP_SESSION_SCREENCAST,
+  XDP_SESSION_REMOTE_DESKTOP,
+} XdpSessionType;
+
+XDP_PUBLIC
+void            xdp_session_close             (XdpSession *session);
+
+XDP_PUBLIC
+XdpSessionType  xdp_session_get_session_type  (XdpSession *session);
+
+G_END_DECLS

--- a/libportal/session.h
+++ b/libportal/session.h
@@ -40,10 +40,48 @@ typedef enum {
   XDP_SESSION_REMOTE_DESKTOP,
 } XdpSessionType;
 
+/**
+ * xdp_portal_create_session:
+ *
+ * Create a new session. This session can later be used to combine
+ * session-based actions from multiple portals into one so they count
+ * as one logical entity.
+ *
+ * When the request is done, @callback will be called. You can then
+ * call [method@Portal.create_session_finish] to get the results.
+ *
+ * This call requires org.freedesktop.portal.Session version 2 or
+ * higher. If this version is not available and for backwards compatibility
+ * this call returns a special XdpSession object that does not
+ * represent a Session on DBus yet. The DBus session will be created
+ * automatically later when either of
+ * xdp_remote_desktop_create_session() or xdp_screencast_create_session()
+ * is called.
+ */
+XDP_PUBLIC
+void            xdp_portal_create_session (XdpPortal            *portal,
+                                           GCancellable         *cancellable,
+                                           GAsyncReadyCallback   callback,
+                                           gpointer              data);
+
+XDP_PUBLIC
+XdpSession *    xdp_portal_create_session_finish (XdpPortal            *portal,
+                                                  GAsyncResult         *result,
+                                                  GError              **error);
+
 XDP_PUBLIC
 void            xdp_session_close             (XdpSession *session);
 
+G_DEPRECATED_FOR(xdp_session_has_session_type)
 XDP_PUBLIC
 XdpSessionType  xdp_session_get_session_type  (XdpSession *session);
+
+/**
+ * xdp_session_has_session_type:
+ *
+ * Returns: true if the given session has the given type.
+ */
+XDP_PUBLIC
+gboolean        xdp_session_has_session_type  (XdpSession *session, XdpSessionType type);
 
 G_END_DECLS

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -16,7 +16,8 @@ if meson.version().version_compare('>= 0.56.0')
       pytest,
       args: ['--verbose', '--log-level=DEBUG'],
       env: test_env,
-      workdir: meson.current_source_dir()
+      workdir: meson.current_source_dir(),
+      timeout: 60,
     )
   endif
 endif

--- a/tests/pyportaltest/templates/__init__.py
+++ b/tests/pyportaltest/templates/__init__.py
@@ -42,6 +42,7 @@ class Request:
             props={},
         )
         self.mock.AddMethod("", "Close", "", "", "self.RemoveObject(self.path)")
+        logger.debug(f"Request created at {self.handle}")
 
     def respond(self, response: Response, delay: int = 0):
         def respond():
@@ -80,6 +81,7 @@ class Session:
             props={},
         )
         self.mock.AddMethod("", "Close", "", "", "self.RemoveObject(self.path)")
+        logger.debug(f"Session created at {self.handle}")
 
     def close(self, details: ASVType, delay: int = 0):
         def respond():

--- a/tests/pyportaltest/templates/__init__.py
+++ b/tests/pyportaltest/templates/__init__.py
@@ -17,6 +17,32 @@ logging.basicConfig(format="%(levelname).1s|%(name)s: %(message)s", level=loggin
 logger = logging.getLogger("templates")
 
 
+class MockParams:
+    """
+    Helper class for storing template parameters. The Mock object passed into
+    ``load()`` is shared between all templates. This makes it easy to have
+    per-template parameters by calling:
+
+        >>> params = MockParams.get(mock, MAIN_IFACE)
+        >>> params.version = 1
+
+    and later, inside a DBus method:
+        >>> params = MockParams.get(self, MAIN_IFACE)
+        >>> return params.version
+    """
+
+    @classmethod
+    def get(cls, mock, interface_name):
+        params = getattr(mock, "params", {})
+        try:
+            return params[interface_name]
+        except KeyError:
+            c = cls()
+            params[interface_name] = c
+            mock.params = params
+            return c
+
+
 class Response(NamedTuple):
     response: int
     results: ASVType

--- a/tests/pyportaltest/templates/remotedesktop.py
+++ b/tests/pyportaltest/templates/remotedesktop.py
@@ -6,6 +6,7 @@ from pyportaltest.templates import Request, Response, Session, ASVType
 from typing import Dict, List, Tuple, Iterator
 from itertools import count
 
+import dbus
 import dbus.service
 import logging
 import socket
@@ -20,7 +21,7 @@ MAIN_IFACE = "org.freedesktop.portal.RemoteDesktop"
 _restore_tokens = count()
 
 
-def load(mock, parameters=None):
+def load(mock, parameters):
     logger.debug(f"loading {MAIN_IFACE} template")
 
     mock.delay = 500

--- a/tests/pyportaltest/templates/remotedesktop.py
+++ b/tests/pyportaltest/templates/remotedesktop.py
@@ -2,7 +2,7 @@
 #
 # This file is formatted with Python Black
 
-from pyportaltest.templates import Request, Response, ASVType
+from pyportaltest.templates import Request, Response, Session, ASVType
 from typing import Dict, List, Tuple, Iterator
 from itertools import count
 
@@ -42,6 +42,8 @@ def load(mock, parameters=None):
         ),
     )
 
+    mock.sessions: Dict[str, Session] = {}
+
 
 @dbus.service.method(
     MAIN_IFACE,
@@ -53,6 +55,9 @@ def CreateSession(self, options, sender):
     try:
         logger.debug(f"CreateSession: {options}")
         request = Request(bus_name=self.bus_name, sender=sender, options=options)
+
+        session = Session(bus_name=self.bus_name, sender=sender, options=options)
+        self.sessions[session.handle] = session
 
         response = Response(self.response, {})
 

--- a/tests/pyportaltest/templates/screencast.py
+++ b/tests/pyportaltest/templates/screencast.py
@@ -2,7 +2,7 @@
 #
 # This file is formatted with Python Black
 
-from pyportaltest.templates import Request, Response, ASVType
+from pyportaltest.templates import Request, Response, Session, ASVType
 from typing import Dict, List, Tuple, Iterator
 from itertools import count
 
@@ -49,6 +49,8 @@ def load(mock, parameters=None):
         ),
     )
 
+    mock.sessions: Dict[str, Session] = {}
+
 
 @dbus.service.method(
     MAIN_IFACE,
@@ -60,6 +62,9 @@ def CreateSession(self, options, sender):
     try:
         logger.debug(f"CreateSession: {options}")
         request = Request(bus_name=self.bus_name, sender=sender, options=options)
+
+        session = Session(bus_name=self.bus_name, sender=sender, options=options)
+        self.sessions[session.handle] = session
 
         response = Response(self.response, {})
 

--- a/tests/pyportaltest/templates/screencast.py
+++ b/tests/pyportaltest/templates/screencast.py
@@ -6,6 +6,7 @@ from pyportaltest.templates import Request, Response, Session, ASVType
 from typing import Dict, List, Tuple, Iterator
 from itertools import count
 
+import dbus
 import dbus.service
 import logging
 import socket
@@ -20,7 +21,7 @@ MAIN_IFACE = "org.freedesktop.portal.ScreenCast"
 _restore_tokens = count()
 
 
-def load(mock, parameters=None):
+def load(mock, parameters):
     logger.debug(f"loading {MAIN_IFACE} template")
 
     mock.delay = 500

--- a/tests/pyportaltest/templates/wallpaper.py
+++ b/tests/pyportaltest/templates/wallpaper.py
@@ -2,7 +2,7 @@
 #
 # This file is formatted with Python Black
 
-from pyportaltest.templates import Request, Response, ASVType
+from pyportaltest.templates import Request, Response, ASVType, MockParams
 from typing import Dict, List, Tuple, Iterator
 
 import dbus
@@ -19,9 +19,10 @@ MAIN_IFACE = "org.freedesktop.portal.Wallpaper"
 
 def load(mock, parameters):
     logger.debug(f"loading {MAIN_IFACE} template")
-    mock.delay = 500
 
-    mock.response = parameters.get("response", 0)
+    params = MockParams.get(mock, MAIN_IFACE)
+    params.delay = 500
+    params.response = parameters.get("response", 0)
 
     mock.AddProperties(
         MAIN_IFACE,
@@ -38,11 +39,12 @@ def load(mock, parameters):
 def SetWallpaperURI(self, parent_window, uri, options, sender):
     try:
         logger.debug(f"SetWallpaperURI: {parent_window}, {uri}, {options}")
+        params = MockParams.get(self, MAIN_IFACE)
         request = Request(bus_name=self.bus_name, sender=sender, options=options)
 
-        response = Response(self.response, {})
+        response = Response(params.response, {})
 
-        request.respond(response, delay=self.delay)
+        request.respond(response, delay=params.delay)
 
         return request.handle
     except Exception as e:

--- a/tests/pyportaltest/templates/wallpaper.py
+++ b/tests/pyportaltest/templates/wallpaper.py
@@ -5,6 +5,7 @@
 from pyportaltest.templates import Request, Response, ASVType
 from typing import Dict, List, Tuple, Iterator
 
+import dbus
 import dbus.service
 import logging
 
@@ -16,7 +17,7 @@ SYSTEM_BUS = False
 MAIN_IFACE = "org.freedesktop.portal.Wallpaper"
 
 
-def load(mock, parameters=None):
+def load(mock, parameters):
     logger.debug(f"loading {MAIN_IFACE} template")
     mock.delay = 500
 

--- a/tests/pyportaltest/test_screencast.py
+++ b/tests/pyportaltest/test_screencast.py
@@ -27,6 +27,7 @@ class SessionCreationFailed(Exception):
 
 class SessionSetup(NamedTuple):
     session: Xdp.Session
+    session_handle_token: str
     pw_fd: TextIO
 
 
@@ -81,6 +82,16 @@ class TestScreenCast(PortalTest):
         if session_error is not None:
             raise SessionCreationFailed(session_error)
 
+        # Extract our expected session id. This isn't available from
+        # XdpSession so we need to go around it. We can't easily get the
+        # sender id so the full path is hard. Let's just extract the token and
+        # pretend that's good enough.
+        method_calls = self.mock_interface.GetMethodCalls("CreateSession")
+        assert len(method_calls) >= 1
+        _, args = method_calls.pop()  # Assume the latest has our session
+        (options,) = args
+        session_handle = options["session_handle_token"]
+
         assert session.get_session_type() == Xdp.SessionType.SCREENCAST
 
         # open the PW remote by default since we need it anyway for Start()
@@ -90,6 +101,7 @@ class TestScreenCast(PortalTest):
 
         return SessionSetup(
             session=session,
+            session_handle_token=session_handle,
             pw_fd=pw_fd,
         )
 
@@ -268,3 +280,31 @@ class TestScreenCast(PortalTest):
         session_handle, parent_window, options = args
         assert parent_window == ""
         assert list(options.keys()) == ["handle_token"]
+
+    def test_close_session(self):
+        """
+        Ensure that closing our session explicitly closes the session on DBus
+        """
+        setup = self.create_session()
+        session = setup.session
+
+        was_closed = False
+
+        def method_called(method_name, method_args, path):
+            nonlocal was_closed
+
+            if method_name == "Close" and path.endswith(setup.session_handle_token):
+                was_closed = True
+                self.mainloop.quit()
+
+        bus = self.get_dbus()
+        bus.add_signal_receiver(
+            handler_function=method_called,
+            signal_name="MethodCalled",
+            dbus_interface="org.freedesktop.DBus.Mock",
+            path_keyword="path",
+        )
+
+        session.close()
+        self.mainloop.run()
+        assert was_closed is True


### PR DESCRIPTION
Motivated by the discussion in  #102. This is on top of #111 with some commits from #102, ignore all but the top commit 

"Detangle Session creation from the RemoteDesktop/ScreenCast portals".

This is merely the propsed API, and only for RD/SC, Location is missing but would look similar.

This requires xdg-desktop-portal
- `portal.SessionFactory`, for `SessionFactory.CreateSession()`
- version 2 of `portal.RemoteDesktop`, for session_handle in `RemoteDesktop.CreateSession`
- version 5 of `portal.ScreenCast`, for session_handle in `ScreenCast.CreateSession`

Previously sessions were created via a `session_handle_token` in the
respective portal's `CreateSession` method. With the `SessionFactory` portal,
we can now create an independent Session and pass the object path
into `CreateSession` as `session_handle`. This allows us to re-use existing
sessions for multiple portals.

The existing API is updated to reflect that, in particular a session may
now have multiple types that can be checked invididually. For the
portal-specific API, the existing functions are deprecated and replaced
by one named after the portal, e.g. `xdp_session_start()` becomes
`xdp_remote_desktop_start()` or `xdp_screencast_start()`.

The `RemoteDesktop` and `ScreenCast` portals however are a bit special,
they're quite intertwined (and partially equivalent) and the session
created for one transparently becomes the other, depending primarily on
`SelectSources`. This leads to some duplication in the public API.

We want new applications to use the new API, so libportal transparently
implements support for older portals by returning a special `XdpSession`
that is unbound but gets created on DBus when calling that portal's
`CreateSession` later. This session object cannot be used for future
session-based portals that require `SessionPortal` to be present.

## Extra note

As for the (currently missing) implementation it's hopefully not too hard to imagine, the `XdpSession` just contains whatever private data the portals need and various checks for the session type prevent wrong access.

The `Location` API would likely need to be updated too for consistency, right now it doesn't allow for multiple sessions.