### PR TITLE
Allow overriding the bus name we connect to

### DIFF
--- a/libportal/portal-private.h
+++ b/libportal/portal-private.h
@@ -53,7 +53,9 @@ struct _XdpPortal {
   guint screencast_interface_version;
 };
 
-#define PORTAL_BUS_NAME "org.freedesktop.portal.Desktop"
+const char * portal_get_bus_name (void);
+
+#define PORTAL_BUS_NAME (portal_get_bus_name ())
 #define PORTAL_OBJECT_PATH  "/org/freedesktop/portal/desktop"
 #define REQUEST_PATH_PREFIX "/org/freedesktop/portal/desktop/request/"
 #define SESSION_PATH_PREFIX "/org/freedesktop/portal/desktop/session/"

--- a/libportal/portal.c
+++ b/libportal/portal.c
@@ -32,6 +32,20 @@
 #endif
 #include <stdio.h>
 
+const char *
+portal_get_bus_name (void)
+{
+  static const char *busname = NULL;
+
+  if (g_once_init_enter (&busname))
+    {
+      const char *env = g_getenv ("LIBPORTAL_PORTAL_BUS_NAME");
+      g_once_init_leave (&busname, env ?: "org.freedesktop.portal.Desktop");
+    }
+
+  return busname;
+}
+
 /**
  * XdpPortal
  *


### PR DESCRIPTION
For debugging it's useful to run against a bus that doesn't require
replacing the real xdg-desktop-portal. Make this possible by setting
the LIBPORTAL_PORTAL_BUS_NAME environment variable.