### PR TITLE
Support RemoteDesktop.ConnectToEIS

### DIFF
--- a/libportal/portal-private.h
+++ b/libportal/portal-private.h
@@ -51,6 +51,7 @@ struct _XdpPortal {
 
   /* screencast */
   guint screencast_interface_version;
+  guint remote_desktop_interface_version;
 
   /* background */
   guint background_interface_version;

--- a/libportal/remote.c
+++ b/libportal/remote.c
@@ -898,6 +898,16 @@ xdp_session_open_pipewire_remote (XdpSession *session)
   return g_unix_fd_list_get (fd_list, fd_out, NULL);
 }
 
+static inline gboolean
+is_active_remote_desktop_session (XdpSession    *session,
+                                  XdpDeviceType  required_device)
+{
+  return XDP_IS_SESSION (session) &&
+         session->type == XDP_SESSION_REMOTE_DESKTOP &&
+         session->state == XDP_SESSION_ACTIVE &&
+         (session->devices & required_device) != 0;
+}
+
 /**
  * xdp_session_pointer_motion:
  * @session: a [class@Session]
@@ -916,10 +926,7 @@ xdp_session_pointer_motion (XdpSession *session,
 {
   GVariantBuilder options;
 
-  g_return_if_fail (XDP_IS_SESSION (session) &&
-                    session->type == XDP_SESSION_REMOTE_DESKTOP &&
-                    session->state == XDP_SESSION_ACTIVE &&
-                    ((session->devices & XDP_DEVICE_POINTER) != 0));
+  g_return_if_fail (is_active_remote_desktop_session (session, XDP_DEVICE_POINTER));
 
   g_variant_builder_init (&options, G_VARIANT_TYPE_VARDICT);
   g_dbus_connection_call (session->portal->bus,
@@ -952,10 +959,7 @@ xdp_session_pointer_position (XdpSession *session,
 {
   GVariantBuilder options;
 
-  g_return_if_fail (XDP_IS_SESSION (session) &&
-                    session->type == XDP_SESSION_REMOTE_DESKTOP &&
-                    session->state == XDP_SESSION_ACTIVE &&
-                    ((session->devices & XDP_DEVICE_POINTER) != 0));
+  g_return_if_fail (is_active_remote_desktop_session (session, XDP_DEVICE_POINTER));
 
   g_variant_builder_init (&options, G_VARIANT_TYPE_VARDICT);
   g_dbus_connection_call (session->portal->bus,
@@ -985,10 +989,7 @@ xdp_session_pointer_button (XdpSession *session,
 {
   GVariantBuilder options;
 
-  g_return_if_fail (XDP_IS_SESSION (session) &&
-                    session->type == XDP_SESSION_REMOTE_DESKTOP &&
-                    session->state == XDP_SESSION_ACTIVE &&
-                    ((session->devices & XDP_DEVICE_POINTER) != 0));
+  g_return_if_fail (is_active_remote_desktop_session (session, XDP_DEVICE_POINTER));
 
   g_variant_builder_init (&options, G_VARIANT_TYPE_VARDICT);
   g_dbus_connection_call (session->portal->bus,
@@ -1022,10 +1023,7 @@ xdp_session_pointer_axis (XdpSession *session,
 {
   GVariantBuilder options;
 
-  g_return_if_fail (XDP_IS_SESSION (session) &&
-                    session->type == XDP_SESSION_REMOTE_DESKTOP &&
-                    session->state == XDP_SESSION_ACTIVE &&
-                    ((session->devices & XDP_DEVICE_POINTER) != 0));
+  g_return_if_fail (is_active_remote_desktop_session (session, XDP_DEVICE_POINTER));
 
   g_variant_builder_init (&options, G_VARIANT_TYPE_VARDICT);
   g_variant_builder_add (&options, "{sv}", "finish", g_variant_new_boolean (finish));
@@ -1056,10 +1054,7 @@ xdp_session_pointer_axis_discrete (XdpSession *session,
 {
   GVariantBuilder options;
 
-  g_return_if_fail (XDP_IS_SESSION (session) &&
-                    session->type == XDP_SESSION_REMOTE_DESKTOP &&
-                    session->state == XDP_SESSION_ACTIVE &&
-                    ((session->devices & XDP_DEVICE_POINTER) != 0));
+  g_return_if_fail (is_active_remote_desktop_session (session, XDP_DEVICE_POINTER));
 
   g_variant_builder_init (&options, G_VARIANT_TYPE_VARDICT);
   g_dbus_connection_call (session->portal->bus,
@@ -1091,10 +1086,7 @@ xdp_session_keyboard_key (XdpSession *session,
 {
   GVariantBuilder options;
 
-  g_return_if_fail (XDP_IS_SESSION (session) &&
-                    session->type == XDP_SESSION_REMOTE_DESKTOP &&
-                    session->state == XDP_SESSION_ACTIVE &&
-                    ((session->devices & XDP_DEVICE_KEYBOARD) != 0));
+  g_return_if_fail (is_active_remote_desktop_session (session, XDP_DEVICE_KEYBOARD));
 
   g_variant_builder_init (&options, G_VARIANT_TYPE_VARDICT);
   g_dbus_connection_call (session->portal->bus,
@@ -1131,10 +1123,7 @@ xdp_session_touch_down (XdpSession *session,
 {
   GVariantBuilder options;
 
-  g_return_if_fail (XDP_IS_SESSION (session) &&
-                    session->type == XDP_SESSION_REMOTE_DESKTOP &&
-                    session->state == XDP_SESSION_ACTIVE &&
-                    ((session->devices & XDP_DEVICE_TOUCHSCREEN) != 0));
+  g_return_if_fail (is_active_remote_desktop_session (session, XDP_DEVICE_TOUCHSCREEN));
 
   g_variant_builder_init (&options, G_VARIANT_TYPE_VARDICT);
   g_dbus_connection_call (session->portal->bus,
@@ -1171,10 +1160,7 @@ xdp_session_touch_position (XdpSession *session,
 {
   GVariantBuilder options;
 
-  g_return_if_fail (XDP_IS_SESSION (session) &&
-                    session->type == XDP_SESSION_REMOTE_DESKTOP &&
-                    session->state == XDP_SESSION_ACTIVE &&
-                    ((session->devices & XDP_DEVICE_TOUCHSCREEN) != 0));
+  g_return_if_fail (is_active_remote_desktop_session (session, XDP_DEVICE_TOUCHSCREEN));
 
   g_variant_builder_init (&options, G_VARIANT_TYPE_VARDICT);
   g_dbus_connection_call (session->portal->bus,
@@ -1202,10 +1188,7 @@ xdp_session_touch_up (XdpSession *session,
 {
   GVariantBuilder options;
 
-  g_return_if_fail (XDP_IS_SESSION (session) &&
-                    session->type == XDP_SESSION_REMOTE_DESKTOP &&
-                    session->state == XDP_SESSION_ACTIVE &&
-                    ((session->devices & XDP_DEVICE_TOUCHSCREEN) != 0));
+  g_return_if_fail (is_active_remote_desktop_session (session, XDP_DEVICE_TOUCHSCREEN));
 
   g_variant_builder_init (&options, G_VARIANT_TYPE_VARDICT);
   g_dbus_connection_call (session->portal->bus,

--- a/libportal/remote.c
+++ b/libportal/remote.c
@@ -905,7 +905,81 @@ is_active_remote_desktop_session (XdpSession    *session,
   return XDP_IS_SESSION (session) &&
          session->type == XDP_SESSION_REMOTE_DESKTOP &&
          session->state == XDP_SESSION_ACTIVE &&
+         !session->uses_eis &&
          (session->devices & required_device) != 0;
+}
+
+/**
+ * xdp_session_connect_to_eis
+ * @session: a [class@Session]
+ * @error: return location for a #GError pointer
+ *
+ * Connect this XdpRemoteDesktopSession to an EIS implementation and return the fd.
+ * This fd can be passed into ei_setup_backend_fd(). See the libei
+ * documentation for details.
+ *
+ * This call must be issued before xdp_session_start(). If successful, all input
+ * event emulation must be handled via the EIS connection and calls to
+ * xdp_session_pointer_motion() etc. are silently ignored.
+ *
+ * Returns: the file descriptor to the EIS implementation
+ */
+int
+xdp_session_connect_to_eis (XdpSession  *session,
+                            GError     **error)
+{
+  XdpPortal *portal = session->portal;
+  GVariantBuilder options;
+  g_autoptr(GVariant) ret = NULL;
+  g_autoptr(GUnixFDList) fd_list = NULL;
+  int fd_out = -1;
+
+  if (portal->remote_desktop_interface_version < 2)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "Not supported by the portal interface");
+      return -1;
+    }
+  else if (session->type != XDP_SESSION_REMOTE_DESKTOP)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT, "Session is not a Remote Desktop session");
+      return -1;
+    }
+  else if (xdp_session_get_session_state (session) != XDP_SESSION_ACTIVE)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT, "Session has not been started");
+      return -1;
+    }
+  else if (session->uses_eis)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT, "Session is already connected to EIS");
+      return -1;
+    }
+
+  g_variant_builder_init (&options, G_VARIANT_TYPE_VARDICT);
+
+  ret = g_dbus_connection_call_with_unix_fd_list_sync (portal->bus,
+                                                       PORTAL_BUS_NAME,
+                                                       PORTAL_OBJECT_PATH,
+                                                       "org.freedesktop.portal.RemoteDesktop",
+                                                       "ConnectToEIS",
+                                                       g_variant_new ("(oa{sv})",
+                                                                      session->id,
+                                                                      &options),
+                                                       NULL,
+                                                       G_DBUS_CALL_FLAGS_NONE,
+                                                       -1,
+                                                       NULL,
+                                                       &fd_list,
+                                                       NULL,
+                                                       error);
+  if (!ret)
+      return -1;
+
+  session->uses_eis = TRUE;
+
+  g_variant_get (ret, "(h)", &fd_out);
+
+  return g_unix_fd_list_get (fd_list, fd_out, NULL);
 }
 
 /**

--- a/libportal/remote.c
+++ b/libportal/remote.c
@@ -357,9 +357,9 @@ create_session (CreateCall *call)
 }
 
 static void
-get_version_returned (GObject *object,
-                      GAsyncResult *result,
-                      gpointer data)
+get_screencast_interface_version_returned (GObject *object,
+                                           GAsyncResult *result,
+                                           gpointer data)
 {
   CreateCall *call = data;
   GError *error = NULL;
@@ -393,7 +393,7 @@ get_screencast_interface_version (CreateCall *call)
                           G_DBUS_CALL_FLAGS_NONE,
                           -1,
                           g_task_get_cancellable (call->task),
-                          get_version_returned,
+                          get_screencast_interface_version_returned,
                           call);
 }
 

--- a/libportal/remote.c
+++ b/libportal/remote.c
@@ -357,6 +357,47 @@ create_session (CreateCall *call)
 }
 
 static void
+get_remote_desktop_interface_version_returned (GObject *object,
+                                               GAsyncResult *result,
+                                               gpointer data)
+{
+  CreateCall *call = data;
+  GError *error = NULL;
+  g_autoptr(GVariant) version_variant = NULL;
+  g_autoptr(GVariant) ret = NULL;
+
+  ret = g_dbus_connection_call_finish (G_DBUS_CONNECTION (object), result, &error);
+  if (error)
+    {
+      g_task_return_error (call->task, error);
+      create_call_free (call);
+      return;
+    }
+
+  g_variant_get_child (ret, 0, "v", &version_variant);
+  call->portal->remote_desktop_interface_version = g_variant_get_uint32 (version_variant);
+
+  create_session (call);
+}
+
+static void
+get_remote_desktop_interface_version (CreateCall *call)
+{
+  g_dbus_connection_call (call->portal->bus,
+                          PORTAL_BUS_NAME,
+                          PORTAL_OBJECT_PATH,
+                          "org.freedesktop.DBus.Properties",
+                          "Get",
+                          g_variant_new ("(ss)", "org.freedesktop.portal.RemoteDesktop", "version"),
+                          NULL,
+                          G_DBUS_CALL_FLAGS_NONE,
+                          -1,
+                          g_task_get_cancellable (call->task),
+                          get_remote_desktop_interface_version_returned,
+                          call);
+}
+
+static void
 get_screencast_interface_version_returned (GObject *object,
                                            GAsyncResult *result,
                                            gpointer data)
@@ -377,7 +418,7 @@ get_screencast_interface_version_returned (GObject *object,
   g_variant_get_child (ret, 0, "v", &version_variant);
   call->portal->screencast_interface_version = g_variant_get_uint32 (version_variant);
 
-  create_session (call);
+  get_remote_desktop_interface_version (call);
 }
 
 static void
@@ -395,6 +436,20 @@ get_screencast_interface_version (CreateCall *call)
                           g_task_get_cancellable (call->task),
                           get_screencast_interface_version_returned,
                           call);
+}
+
+static void
+get_portal_interface_versions (CreateCall *call)
+{
+  g_assert (call != NULL);
+  g_assert (call->portal != NULL);
+
+  if (call->portal->screencast_interface_version == 0)
+    get_screencast_interface_version (call);
+  else if (call->portal->remote_desktop_interface_version == 0)
+    get_remote_desktop_interface_version (call);
+  else
+    create_session (call);
 }
 
 /**
@@ -441,10 +496,7 @@ xdp_portal_create_screencast_session (XdpPortal *portal,
   call->multiple = (flags & XDP_SCREENCAST_FLAG_MULTIPLE) != 0;
   call->task = g_task_new (portal, cancellable, callback, data);
 
-  if (portal->screencast_interface_version == 0)
-    get_screencast_interface_version (call);
-  else
-    create_session (call);
+  get_portal_interface_versions (call);
 }
 
 /**
@@ -516,7 +568,7 @@ xdp_portal_create_remote_desktop_session (XdpPortal *portal,
   call->multiple = (flags & XDP_REMOTE_DESKTOP_FLAG_MULTIPLE) != 0;
   call->task = g_task_new (portal, cancellable, callback, data);
 
-  create_session (call);
+  get_portal_interface_versions (call);
 }
 
 /**

--- a/libportal/remote.h
+++ b/libportal/remote.h
@@ -200,6 +200,10 @@ XDP_PUBLIC
 GVariant *      xdp_session_get_streams       (XdpSession *session);
 
 XDP_PUBLIC
+int       xdp_session_connect_to_eis    (XdpSession  *session,
+                                         GError     **error);
+
+XDP_PUBLIC
 void      xdp_session_pointer_motion    (XdpSession *session,
                                          double      dx,
                                          double      dy);

--- a/libportal/session-private.h
+++ b/libportal/session-private.h
@@ -33,6 +33,7 @@ struct _XdpSession {
 
   XdpPersistMode persist_mode;
   char *restore_token;
+  gboolean uses_eis;
 
   guint signal_id;
 };

--- a/tests/pyportaltest/templates/remotedesktop.py
+++ b/tests/pyportaltest/templates/remotedesktop.py
@@ -26,7 +26,7 @@ def load(mock, parameters):
 
     params = MockParams.get(mock, MAIN_IFACE)
     params.delay = 500
-    params.version = parameters.get("version", 1)
+    params.version = parameters.get("version", 2)
     params.response = parameters.get("response", 0)
     params.devices = parameters.get("devices", 0b111)
     params.sessions: Dict[str, Session] = {}
@@ -243,5 +243,26 @@ def NotifyTouchMotion(self, session_handle, options, stream, slot, x, y):
 def NotifyTouchUp(self, session_handle, options, slot):
     try:
         logger.debug(f"NotifyTouchMotion: {session_handle} {options} {slot}")
+    except Exception as e:
+        logger.critical(e)
+
+
+@dbus.service.method(
+    MAIN_IFACE,
+    in_signature="oa{sv}",
+    out_signature="h",
+)
+def ConnectToEIS(self, session_handle, options):
+    try:
+        logger.debug(f"ConnectToEIS: {session_handle} {options}")
+        import socket
+
+        sockets = socket.socketpair()
+        # Write some random data down so it'll break anything that actually
+        # expects the socket to be a real EIS socket
+        sockets[0].send(b"VANILLA")
+        fd = sockets[1]
+        logger.debug(f"ConnectToEIS with fd {fd.fileno()}")
+        return dbus.types.UnixFd(fd)
     except Exception as e:
         logger.critical(e)

--- a/tests/pyportaltest/test_remotedesktop.py
+++ b/tests/pyportaltest/test_remotedesktop.py
@@ -59,9 +59,7 @@ class TestRemoteDesktop(PortalTest):
         params = params or {}
         # To make the tests easier, load ScreenCast automatically if we have
         # any outputs specified.
-        extra_templates = []
-        if outputs:
-            extra_templates = [("ScreenCast", {})]
+        extra_templates = [("ScreenCast", {})]
         self.setup_daemon(params=params, extra_templates=extra_templates)
 
         xdp = Xdp.Portal.new()
@@ -182,6 +180,7 @@ class TestRemoteDesktop(PortalTest):
             "types",
             "multiple",
             "cursor_mode",
+            "persist_mode",
         ]
 
         assert options["types"] == outputs

--- a/tests/pyportaltest/test_screencast.py
+++ b/tests/pyportaltest/test_screencast.py
@@ -46,7 +46,8 @@ class TestScreenCast(PortalTest):
         persist_mode=Xdp.PersistMode.NONE,
         restore_token=None,
     ) -> SessionSetup:
-        self.setup_daemon(params or {})
+        extra_templates = [("RemoteDesktop", {})]
+        self.setup_daemon(params=params or {}, extra_templates=extra_templates)
 
         xdp = Xdp.Portal.new()
         assert xdp is not None


### PR DESCRIPTION
See https://github.com/flatpak/xdg-desktop-portal/pull/762

This adds support for connecting a remote desktop/screen cast session to an [EIS implementation](https://gitlab.freedesktop.org/libinput/libei/) so the application and the EIS implementation (i.e. the compositor) can talk directly without having to bounce DBus messages through the portal.

cc @jadah, @ofourdah