### PR TITLE
CI: bump some actions to newer versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libglib2.0 gettext dbus meson libgirepository1.0-dev libgtk-3-dev valac python3-pytest python3-dbusmock
       - name: Check out libportal
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: Configure libportal
         run: meson setup --prefix=/usr _build -Dbackends=gtk3 -Ddocs=false
       - name: Build libportal
@@ -41,7 +41,7 @@ jobs:
           pip3 install gi-docgen
           echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: Check out libportal
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: Configure libportal
         run: meson setup --prefix=/usr _build -Dbackends=gtk3,gtk4
       - name: Build libportal
@@ -60,7 +60,7 @@ jobs:
         run: |
           dnf install -y meson gcc gobject-introspection-devel gtk3-devel gtk4-devel gi-docgen vala git python3-pytest python3-dbusmock
       - name: Check out libportal
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: Configure libportal
         run: meson setup --prefix=/usr _build -Dbackends=gtk3,gtk4
       - name: Build libportal
@@ -90,7 +90,9 @@ jobs:
           curl https://gitlab.freedesktop.org/hadess/check-abi/-/raw/main/contrib/check-abi-fedora.sh | bash
           rm -rf check-abi/
       - name: Check out libportal
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Work around git safe directory check
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
       - name: Run ABI check

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -19,7 +19,7 @@ jobs:
       options: --privileged
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build GTK3 portal test
         uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v3
@@ -36,7 +36,7 @@ jobs:
       options: --privileged
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build GTK4 portal test
         uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v3
@@ -53,7 +53,7 @@ jobs:
       options: --privileged
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build Qt5 portal test
         uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v3


### PR DESCRIPTION
Node 12 is deprecated so let's bump the actions to newer versions that use Node 16. See 
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/