### PR TITLE
portal: use GInitable to enable init error propagation

### DIFF
--- a/libportal/portal-helpers.h
+++ b/libportal/portal-helpers.h
@@ -36,6 +36,9 @@ XDP_PUBLIC
 XdpPortal *xdp_portal_new                   (void);
 
 XDP_PUBLIC
+XdpPortal *xdp_portal_initable_new          (GError **error);
+
+XDP_PUBLIC
 gboolean   xdp_portal_running_under_flatpak (void);
 
 XDP_PUBLIC

--- a/libportal/portal.c
+++ b/libportal/portal.c
@@ -357,7 +357,7 @@ XdpPortal *
 xdp_portal_new (void)
 {
   g_autoptr(GError) error = NULL;
-  XdpPortal *portal = xdp_portal_initable_new(&error);
+  XdpPortal *portal = xdp_portal_initable_new (&error);
   if (error)
     {
       g_critical ("Failed to create XdpPortal instance: %s\n", error->message);


### PR DESCRIPTION
Fix issue #118

Adds `xdp_portal_initable_new` as an alterative to `xdp_portal_new` that can return a GError.

I used https://gitlab.gnome.org/GNOME/glib/-/blob/main/gio/gcharsetconverter.c as a reference to see how to implement the `GInitable` interface.