### PR TITLE
flatpak.yml: bump actions version, container image

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -15,14 +15,14 @@ jobs:
     name: GTK3
     runs-on: ubuntu-latest
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-42
+      image: bilelmoussaoui/flatpak-github-actions:gnome-44
       options: --privileged
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Build GTK3 portal test
-        uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v3
+        uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v6
         with:
           bundle: portal-test-gtk3.flatpak
           manifest-path: build-aux/org.gnome.PortalTest.Gtk3.json
@@ -32,14 +32,14 @@ jobs:
     name: GTK4
     runs-on: ubuntu-latest
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-42
+      image: bilelmoussaoui/flatpak-github-actions:gnome-44
       options: --privileged
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Build GTK4 portal test
-        uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v3
+        uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v6
         with:
           bundle: portal-test-gtk4.flatpak
           manifest-path: build-aux/org.gnome.PortalTest.Gtk4.json
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build Qt5 portal test
-        uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v3
+        uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v6
         with:
           bundle: portal-test-qt.flatpak
           manifest-path: build-aux/org.gnome.PortalTest.Qt5.json


### PR DESCRIPTION
## Changes

- Bump `flatpak-builder` to `v6`.
- Bump GNOME container image to `44`.