### PR TITLE
CI: use the github action's set-safe-directory instead of a manual run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,5 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Work around git safe directory check
-        run: git config --global --add safe.directory $GITHUB_WORKSPACE
       - name: Run ABI check
         run: check-abi --old-parameters="-Dvapi=false -Ddocs=false -Dintrospection=false" --new-parameters="-Dvapi=false -Ddocs=false -Dtests=false -Dintrospection=false" ${LAST_ABI_BREAK} $GITHUB_SHA


### PR DESCRIPTION
Now that we have checkout@v3, we can use that argument instead of manually calling out to git.

Fixes 2e1eadea760cbcef5ce388ed81421388e989489c