### PR TITLE
Restore ability to call g_object_new (XDP_TYPE_PORTAL, ...)

### DIFF
--- a/libportal/portal-private.h
+++ b/libportal/portal-private.h
@@ -25,6 +25,7 @@
 struct _XdpPortal {
   GObject parent_instance;
 
+  GError *init_error;
   GDBusConnection *bus;
   char *sender;
 


### PR DESCRIPTION
Calling `g_object_new()` for an XdpPortal used to work before 0.7, but no longer sets up the GDBusConnection, making most method calls fail with `assertion 'G_IS_DBUS_CONNECTION (connection)' failed`. This makes #119 an incompatible change.

In particular, the GTK 4 test app calls `new Xdp.Portal()`, which is a JavaScript binding for `g_object_new()` and fails in this way. GObject documentation suggests that bindings should automatically detect types that implement GInitable and call GInitable.init in the higher-level language's constructor, but it seems that neither gjs nor pygobject actually does this.

Mostly preserve previous functionality by moving the actual initialization back to the GObject instance init function, and making the GInitable init function just report a pre-existing error if any.

---

Found while using the GTK 3 and 4 portal tests to smoke-test an updated package for 0.7 in Debian. The GTK 3 test app (written in C) still works, but the GTK 4 test app (in JavaScript) does not.