### PR TITLE
remote: Add API to allow for persistence on RemoteDesktop sessions

### DIFF
--- a/libportal/remote.h
+++ b/libportal/remote.h
@@ -165,6 +165,19 @@ void        xdp_portal_create_remote_desktop_session        (XdpPortal          
                                                              gpointer                data);
 
 XDP_PUBLIC
+void        xdp_portal_create_remote_desktop_session_full   (XdpPortal              *portal,
+                                                             XdpDeviceType           devices,
+                                                             XdpOutputType           outputs,
+                                                             XdpRemoteDesktopFlags   flags,
+                                                             XdpCursorMode           cursor_mode,
+                                                             XdpPersistMode          persist_mode,
+                                                             const char             *restore_token,
+                                                             GCancellable           *cancellable,
+                                                             GAsyncReadyCallback     callback,
+                                                             gpointer                data);
+
+
+XDP_PUBLIC
 XdpSession *xdp_portal_create_remote_desktop_session_finish (XdpPortal              *portal,
                                                              GAsyncResult           *result,
                                                              GError                **error);


### PR DESCRIPTION
Same as the ScreenCast API

Fixes #127

cc @jadahl


Marking as Draft until I've sold off the right to rename this to a more sensible function name to the highest bidder. Any suggestions?