### PR TITLE
portal-test/gtk3: Don't provide a run target if we cannot run it

### DIFF
--- a/portal-test/gtk3/meson.build
+++ b/portal-test/gtk3/meson.build
@@ -32,6 +32,8 @@ executable('portal-linking-test-gtk3',
   dependencies: [libportal_gtk3_dep],
 )
 
-run_target('portal-test-gtk3',
-  command: portal_test_gtk3,
-)
+if meson.can_run_host_binaries()
+  run_target('portal-test-gtk3',
+    command: portal_test_gtk3,
+  )
+endif


### PR DESCRIPTION
If we define a run_target, Meson assumes that it's functionally necessary and will refuse to configure without an exe_wrapper if cross-compiling. This particular run_target is just for convenience, so skip it if we're cross-compiling and don't have an exe_wrapper available.

---

For context, I've been experimenting with cross-compiling packages in the GNOME ecosystem in Debian, and I found libportal to be a convenient example because it's small and quick to compile while also being reasonably complicated (multiple libraries, GTK 3/4, Qt, GObject-Introspection, Vala binding).