### PR TITLE
ci: Add dedicated job for documentation pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,14 +65,6 @@ jobs:
         run: meson setup --prefix=/usr _build -Dbackend-gtk3=enabled -Dbackend-gtk4=enabled -Dbackend-qt5=enabled -Dbackend-qt6=enabled
       - name: Build libportal
         run: ninja -C_build
-      - name: Deploy Docs
-        uses: peaceiris/actions-gh-pages@v3
-        if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./_build/doc/libportal-1/
-          cname: libportal.org
-          destination_dir: ./
 
   abi-check:
     name: ABI check

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,61 @@
+name: Documentation
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:latest
+
+    steps:
+      - name: Install dependencies
+        run: |
+          dnf install -y \
+            gcc \
+            gi-docgen \
+            git \
+            gobject-introspection-devel \
+            meson \
+            python3-pytest \
+            python3-dbusmock
+
+      - name: Check out libportal
+        uses: actions/checkout@v4
+
+      - name: Configure libportal
+        run: meson setup --prefix=/usr builddir -Dtests=false -Dvapi=false
+
+      - name: Build libportal
+        run: ninja -C builddir doc/libportal-1
+
+      - name: Prepare docs
+        working-directory: builddir/doc
+        run: |
+          mv ./libportal-1 ../../_site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  # Deployment job
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
The Fedora jobs build and deploy documentation twice, and that may be a problem.

Use a dedicated workflow with proper a deploy job. This uses the Github Pages deploy action.