### PR TITLE
Improve convenience scripts for building demos as Flatpak apps

### DIFF
--- a/build-aux/org.gnome.PortalTest.Gtk3.json
+++ b/build-aux/org.gnome.PortalTest.Gtk3.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.PortalTest.Gtk3",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "43",
+    "runtime-version": "45",
     "sdk": "org.gnome.Sdk",
     "command": "portal-test-gtk3",
     "finish-args": [

--- a/build-aux/org.gnome.PortalTest.Gtk3.json
+++ b/build-aux/org.gnome.PortalTest.Gtk3.json
@@ -32,6 +32,9 @@
             "builddir": true,
             "config-opts": [
               "-Dbackend-gtk3=enabled",
+              "-Dbackend-gtk4=disabled",
+              "-Dbackend-qt5=disabled",
+              "-Dbackend-qt6=disabled",
               "-Dportal-tests=true",
               "-Ddocs=false"
             ],

--- a/build-aux/org.gnome.PortalTest.Gtk4.json
+++ b/build-aux/org.gnome.PortalTest.Gtk4.json
@@ -16,7 +16,10 @@
             "buildsystem": "meson",
             "builddir": true,
             "config-opts": [
+              "-Dbackend-gtk3=disabled",
               "-Dbackend-gtk4=enabled",
+              "-Dbackend-qt5=disabled",
+              "-Dbackend-qt6=disabled",
               "-Dportal-tests=true",
               "-Ddocs=false"
             ],

--- a/build-aux/org.gnome.PortalTest.Gtk4.json
+++ b/build-aux/org.gnome.PortalTest.Gtk4.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.PortalTest.Gtk4",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "43",
+    "runtime-version": "45",
     "sdk": "org.gnome.Sdk",
     "command": "org.gnome.PortalTest.Gtk4",
     "finish-args": [

--- a/build-aux/org.gnome.PortalTest.Qt5.json
+++ b/build-aux/org.gnome.PortalTest.Qt5.json
@@ -15,7 +15,10 @@
             "buildsystem": "meson",
             "builddir": true,
             "config-opts": [
+              "-Dbackend-gtk3=disabled",
+              "-Dbackend-gtk4=disabled",
               "-Dbackend-qt5=enabled",
+              "-Dbackend-qt6=disabled",
               "-Dportal-tests=true",
               "-Dintrospection=false",
               "-Dvapi=false",

--- a/build-aux/org.gnome.PortalTest.Qt6.json
+++ b/build-aux/org.gnome.PortalTest.Qt6.json
@@ -15,6 +15,9 @@
             "buildsystem": "meson",
             "builddir": true,
             "config-opts": [
+              "-Dbackend-gtk3=disabled",
+              "-Dbackend-gtk4=disabled",
+              "-Dbackend-qt5=disabled",
               "-Dbackend-qt6=enabled",
               "-Dportal-tests=true",
               "-Dintrospection=false",


### PR DESCRIPTION
* build-aux: Explicitly disable backends other than the one we want
    
    Otherwise, building in the GNOME SDK will automatically enable both
    Gtk3 and Gtk4 in both apps, even though we wanted each one to have only
    the selected toolkit.

* build-aux: Update to current GNOME SDK