### PR TITLE
meson.build: fix build race when building GTK vapi files

### DIFF
--- a/libportal/meson.build
+++ b/libportal/meson.build
@@ -168,7 +168,7 @@ if gtk3_dep.found()
     if vapi
       libportal_gtk3_vapi = gnome.generate_vapi('libportal-gtk3',
         sources: libportal_gtk3_gir[0],
-        packages: ['gio-2.0', 'gtk+-3.0', 'libportal'],
+        packages: ['gio-2.0', 'gtk+-3.0', libportal_vapi],
         gir_dirs: [meson.current_build_dir()],
         vapi_dirs: [meson.current_build_dir()],
         install: true,
@@ -227,7 +227,7 @@ if gtk4_dep.found()
     if vapi
       libportal_gtk4_vapi = gnome.generate_vapi('libportal-gtk4',
         sources: libportal_gtk4_gir[0],
-        packages: ['gio-2.0', 'gtk4', 'libportal'],
+        packages: ['gio-2.0', 'gtk4', libportal_vapi],
         gir_dirs: [meson.current_build_dir()],
         vapi_dirs: [meson.current_build_dir()],
         install: true,


### PR DESCRIPTION
There's a build race when building the GTK vapi files:

FAILED: libportal/libportal-gtk4.vapi
error: Package `libportal' not found in specified Vala API directories or GObject-Introspection GIR directories

This can be verified by adding "sleep 10;" to the command for the libportal/libportal.vapi target in the generated build.ninja file.

The GTK vapi files need to have access to the generic libportal.vapi file, but there is no explicit dependency.  Switch the dependency name 'libportal' to the dependency object libportal_vapi so that Meson generates the dependency correctly.