### PR TITLE
Minor fixes for pytest

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -17,7 +17,7 @@ if meson.version().version_compare('>= 0.56.0')
 
     test('pytest',
       pytest,
-      args: ['--verbose', '--log-level=DEBUG'],
+      args: ['--verbose', '--verbose', '--log-level=DEBUG'],
       env: test_env,
       workdir: meson.current_source_dir(),
       timeout: 60,

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -20,7 +20,7 @@ if meson.version().version_compare('>= 0.56.0')
       args: ['--verbose', '--verbose', '--log-level=DEBUG'],
       env: test_env,
       workdir: meson.current_source_dir(),
-      timeout: 60,
+      timeout: 180,
     )
   endif
 endif


### PR DESCRIPTION
* tests: Make pytest more verbose
    
    The difference between sets of strings is unhelpfully truncated
    when `--verbose` is only used once.

* tests: Increase timeout for pytest
    
    On my laptop this test now takes 55 seconds, which is uncomfortably
    close to the 60s timeout.