### PR TITLE
Fix an Input Capture test failure

### DIFF
--- a/tests/pyportaltest/test_inputcapture.py
+++ b/tests/pyportaltest/test_inputcapture.py
@@ -637,6 +637,7 @@ class TestInputCapture(PortalTest):
         def session_closed(session):
             nonlocal session_closed_signal_received
             session_closed_signal_received = True
+            self.mainloop.quit()
 
         xdp_session.connect("closed", session_closed)
 


### PR DESCRIPTION
It's only reproducible on `meson dist` for some reason, `meson test` runs fine.