### PR TITLE
notification: Ensure that g_autoptr variable is initialized

### DIFF
--- a/libportal/notification.c
+++ b/libportal/notification.c
@@ -486,7 +486,7 @@ parse_notification (GVariant            *notification,
   GVariant *value = NULL;
   g_autoptr(GVariant) properties = NULL;
   ParserData *data;
-  g_autoptr(GTask) task;
+  g_autoptr(GTask) task = NULL;
   const char *supported_properties_v1[] = {
     "title",
     "body",


### PR DESCRIPTION
If the function early-returns (which it currently does not, but that would be a reasonable change to make) then we'd call g_object_unref() on uninitialized stack memory. gcc 14.2.0 in the freedesktop SDK 24.08 warns about this.

It's better to make sure that every autofreed variable is initialized, possibly to NULL.