### PR TITLE
Fix some Meson warnings by officially requiring 0.55.0

### DIFF
--- a/libportal/meson.build
+++ b/libportal/meson.build
@@ -242,7 +242,7 @@ endif
 # Qt 5 #
 ########
 
-have_cpp = add_languages('cpp', required: get_option('backend-qt5'))
+have_cpp = add_languages('cpp', required: get_option('backend-qt5'), native: false)
 qt5_dep = dependency('qt5', modules: ['Core', 'Gui', 'X11Extras', 'Widgets'], required: get_option('backend-qt5'))
 
 if have_cpp and qt5_dep.found()
@@ -279,7 +279,7 @@ endif
 ########
 
 if meson.version().version_compare('>= 0.63.0')
-   have_cpp = add_languages('cpp', required: get_option('backend-qt6'))
+   have_cpp = add_languages('cpp', required: get_option('backend-qt6'), native: false)
    qt6_dep = dependency('qt6', modules: ['Core', 'Gui', 'Widgets'], private_headers: true, required: get_option('backend-qt6'))
 
    if have_cpp and qt6_dep.found()

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('libportal','c',
         version: '0.9.1',
         default_options: ['warning_level=2'],
-        meson_version: '>= 0.49.0')
+        meson_version: '>= 0.55.0')
 
 cc = meson.get_compiler('c')
 cflags = [

--- a/portal-test/gtk4/meson.build
+++ b/portal-test/gtk4/meson.build
@@ -25,7 +25,7 @@ js_resouces = gnome.compile_resources(
 )
 
 bin_conf = configuration_data()
-bin_conf.set('GJS', find_program('gjs').path())
+bin_conf.set('GJS', find_program('gjs').full_path())
 bin_conf.set('PACKAGE_NAME', package_name)
 bin_conf.set('PACKAGE_VERSION', '1.0.0')
 bin_conf.set('prefix', get_option('prefix'))

--- a/portal-test/qt5/meson.build
+++ b/portal-test/qt5/meson.build
@@ -1,5 +1,5 @@
 
-add_languages('cpp', required : true)
+add_languages('cpp', required : true, native : false)
 
 src = [
   'main.cpp',

--- a/portal-test/qt6/meson.build
+++ b/portal-test/qt6/meson.build
@@ -1,5 +1,5 @@
 
-add_languages('cpp', required : true)
+add_languages('cpp', required : true, native : false)
 
 src = [
   'main.cpp',

--- a/tests/qt5/meson.build
+++ b/tests/qt5/meson.build
@@ -1,4 +1,4 @@
-add_languages('cpp', required : true)
+add_languages('cpp', required : true, native : false)
 
 qt5_dep = dependency('qt5', modules: ['Core', 'Test'])
 

--- a/tests/qt6/meson.build
+++ b/tests/qt6/meson.build
@@ -1,4 +1,4 @@
-add_languages('cpp', required : true)
+add_languages('cpp', required : true, native : false)
 
 qt6_dep = dependency('qt6', modules: ['Core', 'Test'])
 


### PR DESCRIPTION
* build: Officially require Meson 0.55.0
    
    In practice the GTK3 backend accidentally required 0.55.0 since 0.8.0,
    and nobody seems to have complained or even noticed.
    
    Fixes: f7f3acf5 "portal-test/gtk3: Don't provide a run target if we cannot run it"

* gtk4: Replace deprecated path() method with full_path()
    
    This raises a deprecation warning with newer Meson, and now that we
    officially require Meson 0.55.0, we can use it unconditionally.

* build: Never require a C++ compiler for the build architecture
    
    Newer Meson issues a warning if we don't specify whether we plan to
    compile code for the build architecture or not when adding a language.
    
    Like most projects, this one doesn't seem to ever compile for the build
    architecture, only for the host architecture, so when cross-compiling it
    will only need a host-architecture C++ compiler.
    
    For example, if we're cross-compiling for riscv64 on x86_64, we
    will need a riscv64 cross-compiler, but we don't need an x86_64 native
    compiler. Instruct Meson not to look for one.

---

Alternatively we could continue to only require 0.49.0 with some simple changes to the gtk3 and gtk4 backends, but Meson ≥ 0.55.0 is available since Debian 10 (which is superseded and EOL) and CentOS/RHEL 8 (which is superseded but I think still supported), so maybe we don't need to go that far into retrocomputing? The main things we'd lose the ability to compile on by bumping the requirement to 0.55.0 are CentOS/RHEL 7 and Ubuntu 20.04, which have been superseded but I believe are still supported to some extent.