### PR TITLE
Remove (closure) annotations

### DIFF
--- a/libportal/account.c
+++ b/libportal/account.c
@@ -206,7 +206,7 @@ get_user_information (AccountCall *call)
  * @flags: options for this call
  * @cancellable: (nullable): optional [class@Gio.Cancellable]
  * @callback: (scope async): a callback to call when the request is done
- * @data: (closure): data to pass to @callback
+ * @data: data to pass to @callback
  *
  * Gets information about the user.
  *

--- a/libportal/background.c
+++ b/libportal/background.c
@@ -326,7 +326,7 @@ request_background (BackgroundCall *call)
  * @flags: options for this call
  * @cancellable: (nullable): optional [class@Gio.Cancellable]
  * @callback: (scope async): a callback to call when the request is done
- * @user_data: (closure): data to pass to @callback
+ * @user_data: data to pass to @callback
  *
  * Requests background permissions.
  *
@@ -396,7 +396,7 @@ xdp_portal_request_background_finish (XdpPortal *portal,
  * @status_message: (nullable): status message when running in background
  * @cancellable: (nullable): optional [class@Gio.Cancellable]
  * @callback: (scope async): a callback to call when the request is done
- * @data: (closure): data to pass to @callback
+ * @data: data to pass to @callback
  *
  * Sets the status information of the application, for when it's running
  * in background.

--- a/libportal/camera.c
+++ b/libportal/camera.c
@@ -215,7 +215,7 @@ access_camera (AccessCameraCall *call)
  * @flags: options for this call
  * @cancellable: (nullable): optional [class@Gio.Cancellable]
  * @callback: (scope async): a callback to call when the request is done
- * @data: (closure): data to pass to @callback
+ * @data: data to pass to @callback
  *
  * Request access to a camera.
  *

--- a/libportal/dynamic-launcher.c
+++ b/libportal/dynamic-launcher.c
@@ -233,7 +233,7 @@ do_prepare_install (PrepareInstallLauncherCall *call)
  * @editable_icon: if %TRUE, the user will be able to edit the icon of the launcher, if the implementation supports this
  * @cancellable: (nullable): optional [class@Gio.Cancellable]
  * @callback: (scope async): a callback to call when the request is done
- * @data: (closure): data to pass to @callback
+ * @data: data to pass to @callback
  *
  * Presents a dialog to the user so they can confirm they want to install a
  * launcher to their desktop.

--- a/libportal/email.c
+++ b/libportal/email.c
@@ -305,7 +305,7 @@ compose_email (EmailCall *call)
  * @flags: options for this call
  * @cancellable: (nullable): optional [class@Gio.Cancellable]
  * @callback: (scope async): a callback to call when the request is done
- * @data: (closure): data to pass to @callback
+ * @data: data to pass to @callback
  *
  * Presents a window that lets the user compose an email,
  * with some pre-filled information.

--- a/libportal/filechooser.c
+++ b/libportal/filechooser.c
@@ -242,7 +242,7 @@ open_file (FileCall *call)
  * @flags: options for this call
  * @cancellable: (nullable): optional [class@Gio.Cancellable]
  * @callback: (scope async): a callback to call when the request is done
- * @data: (closure): data to pass to @callback
+ * @data: data to pass to @callback
  *
  * Asks the user to open one or more files.
  *
@@ -350,7 +350,7 @@ xdp_portal_open_file_finish (XdpPortal *portal,
  * @flags: options for this call
  * @cancellable: (nullable): optional [class@Gio.Cancellable]
  * @callback: (scope async): a callback to call when the request is done
- * @data: (closure): data to pass to @callback
+ * @data: data to pass to @callback
  *
  * Asks the user for a location to save a file.
  *
@@ -443,7 +443,7 @@ xdp_portal_save_file_finish (XdpPortal *portal,
  * @flags: options for this call
  * @cancellable: (nullable): optional [class@Gio.Cancellable]
  * @callback: (scope async): a callback to call when the request is done
- * @data: (closure): data to pass to @callback
+ * @data: data to pass to @callback
  *
  * Asks for a folder as a location to save one or more files.
  *

--- a/libportal/inhibit.c
+++ b/libportal/inhibit.c
@@ -215,7 +215,7 @@ do_inhibit (InhibitCall *call)
  * @flags: information about what to inhibit
  * @cancellable: (nullable): optional [class@Gio.Cancellable]
  * @callback: (scope async): a callback to call when the request is done
- * @data: (closure): data to pass to @callback
+ * @data: data to pass to @callback
  *
  * Inhibits various session status changes.
  *
@@ -566,7 +566,7 @@ create_monitor (CreateMonitorCall *call)
  * @flags: options for this call
  * @cancellable: (nullable): optional [class@Gio.Cancellable]
  * @callback: (scope async): a callback to call when the request is done
- * @data: (closure): data to pass to @callback
+ * @data: data to pass to @callback
  *
  * Makes [class@Portal] start monitoring the login session state.
  *

--- a/libportal/inputcapture.c
+++ b/libportal/inputcapture.c
@@ -724,7 +724,7 @@ create_session (Call *call)
  * @capabilities: which kinds of capabilities to request
  * @cancellable: (nullable): optional [class@Gio.Cancellable]
  * @callback: (scope async): a callback to call when the request is done
- * @data: (closure): data to pass to @callback
+ * @data: data to pass to @callback
  *
  * Creates a session for input capture
  *

--- a/libportal/location.c
+++ b/libportal/location.c
@@ -327,7 +327,7 @@ create_session (CreateCall *call)
  * @flags: options for this call
  * @cancellable: (nullable): optional [class@Gio.Cancellable]
  * @callback: (scope async): a callback to call when the request is done
- * @data: (closure): data to pass to @callback
+ * @data: data to pass to @callback
  *
  * Makes `XdpPortal` start monitoring location changes.
  *

--- a/libportal/notification.c
+++ b/libportal/notification.c
@@ -720,7 +720,7 @@ get_supported_features_cb (GObject      *source_object,
  * @flags: options for this call
  * @cancellable: (nullable): optional [class@Gio.Cancellable]
  * @callback: (scope async): a callback to call when the request is done
- * @data: (closure): data to pass to @callback
+ * @data: data to pass to @callback
  *
  * Sends a desktop notification.
  *

--- a/libportal/openuri.c
+++ b/libportal/openuri.c
@@ -274,7 +274,7 @@ do_open (OpenCall *call)
  * @flags: options for this call
  * @cancellable: (nullable): optional [class@Gio.Cancellable]
  * @callback: (scope async): a callback to call when the request is done
- * @data: (closure): data to pass to @callback
+ * @data: data to pass to @callback
  *
  * Opens @uri with an external handler.
  */
@@ -341,7 +341,7 @@ xdp_portal_open_uri_finish (XdpPortal *portal,
  * @flags: options for this call
  * @cancellable: (nullable): optional [class@Gio.Cancellable]
  * @callback: (scope async): a callback to call when the request is done
- * @data: (closure): data to pass to @callback
+ * @data: data to pass to @callback
  *
  * Opens the directory containing the file specified by the @uri.
  *

--- a/libportal/print.c
+++ b/libportal/print.c
@@ -277,7 +277,7 @@ do_print (PrintCall *call)
  * @flags: options for this call
  * @cancellable: (nullable): optional [class@Gio.Cancellable]
  * @callback: (scope async): a callback to call when the request is done
- * @data: (closure): data to pass to @callback
+ * @data: data to pass to @callback
  * 
  * Presents a print dialog to the user and returns print settings and page setup.
  *
@@ -355,7 +355,7 @@ xdp_portal_prepare_print_finish (XdpPortal *portal,
  * @flags: options for this call
  * @cancellable: (nullable): optional [class@Gio.Cancellable]
  * @callback: (scope async): a callback to call when the request is done
- * @data: (closure): data to pass to @callback
+ * @data: data to pass to @callback
  * 
  * Prints a file.
  *

--- a/libportal/remote.c
+++ b/libportal/remote.c
@@ -457,7 +457,7 @@ get_remote_desktop_interface_version (CreateCall *call)
  * @restore_token: (nullable): the token of a previous screencast session to restore
  * @cancellable: (nullable): optional [class@Gio.Cancellable]
  * @callback: (scope async): a callback to call when the request is done
- * @data: (closure): data to pass to @callback
+ * @data: data to pass to @callback
  *
  * Creates a session for a screencast.
  *
@@ -527,7 +527,7 @@ xdp_portal_create_screencast_session_finish (XdpPortal *portal,
  * @cursor_mode: the cursor mode of the session
  * @cancellable: (nullable): optional [class@Gio.Cancellable]
  * @callback: (scope async): a callback to call when the request is done
- * @data: (closure): data to pass to @callback
+ * @data: data to pass to @callback
  *
  * Creates a session for remote desktop.
  *
@@ -567,7 +567,7 @@ xdp_portal_create_remote_desktop_session (XdpPortal *portal,
  * @restore_token: (nullable): the token of a previous screencast session to restore
  * @cancellable: (nullable): optional [class@Gio.Cancellable]
  * @callback: (scope async): a callback to call when the request is done
- * @data: (closure): data to pass to @callback
+ * @data: data to pass to @callback
  *
  * Creates a session for remote desktop.
  *
@@ -805,7 +805,7 @@ start_session (StartCall *call)
  * @parent: (nullable): parent window information
  * @cancellable: (nullable): optional [class@Gio.Cancellable]
  * @callback: (scope async): a callback to call when the request is done
- * @data: (closure): data to pass to @callback
+ * @data: data to pass to @callback
  *
  * Starts the session.
  *

--- a/libportal/screenshot.c
+++ b/libportal/screenshot.c
@@ -221,7 +221,7 @@ take_screenshot (ScreenshotCall *call)
  * @flags: options for this call
  * @cancellable: (nullable): optional [class@Gio.Cancellable]
  * @callback: (scope async): a callback to call when the request is done
- * @data: (closure): data to pass to @callback
+ * @data: data to pass to @callback
  *
  * Takes a screenshot.
  *
@@ -285,7 +285,7 @@ xdp_portal_take_screenshot_finish (XdpPortal *portal,
  * @parent: (nullable): parent window information
  * @cancellable: (nullable): optional [class@Gio.Cancellable]
  * @callback: (scope async): a callback to call when the request is done
- * @data: (closure): data to pass to @callback
+ * @data: data to pass to @callback
  *
  * Lets the user pick a color from the screen.
  * 

--- a/libportal/spawn.c
+++ b/libportal/spawn.c
@@ -200,7 +200,7 @@ do_spawn (SpawnCall *call)
  * @sandbox_expose_ro: (array zero-terminated) (nullable): paths to expose ro in the new sandbox, or `NULL`
  * @cancellable: (nullable): optional [class@Gio.Cancellable]
  * @callback: (scope async): a callback to call when the request is done
- * @data: (closure): data to pass to @callback
+ * @data: data to pass to @callback
  *
  * Creates a new copy of the applications sandbox, and runs
  * a process in, with the given arguments.

--- a/libportal/trash.c
+++ b/libportal/trash.c
@@ -125,7 +125,7 @@ trash_file (TrashCall *call)
  * @path: the path for a local file
  * @cancellable: (nullable): optional [class@Gio.Cancellable]
  * @callback: (scope async): a callback to call when the request is done
- * @data: (closure): data to pass to @callback
+ * @data: data to pass to @callback
  *
  * Sends the file at @path to the trash can.
  */

--- a/libportal/updates.c
+++ b/libportal/updates.c
@@ -205,7 +205,7 @@ create_monitor (CreateMonitorCall *call)
  * @flags: options for this cal..
  * @cancellable: (nullable): optional [class@Gio.Cancellable]
  * @callback: (scope async): a callback to call when the request is done
- * @data: (closure): data to pass to @callback
+ * @data: data to pass to @callback
  *
  * Makes `XdpPortal` start monitoring for available software updates.
  *
@@ -388,7 +388,7 @@ install_update (InstallUpdateCall *call)
  * @flags: options for this call
  * @cancellable: (nullable): optional [class@Gio.Cancellable]
  * @callback: (scope async): a callback to call when the request is done
- * @data: (closure): data to pass to @callback
+ * @data: data to pass to @callback
  *
  * Installs an available software update.
  *

--- a/libportal/wallpaper.c
+++ b/libportal/wallpaper.c
@@ -283,7 +283,7 @@ set_wallpaper (WallpaperCall *call)
  * @flags: options for this call
  * @cancellable: (nullable): optional [class@Gio.Cancellable]
  * @callback: (scope async): a callback to call when the request is done
- * @data: (closure): data to pass to @callback
+ * @data: data to pass to @callback
  *
  * Sets a desktop background image, given by a uri.
  */


### PR DESCRIPTION
The `(closure)` annotation should go in the callback parameter, e.g.

`* @callback: (scope async) (closure data): a callback ...`

however gobject-introspection will automatically pick up a parameter called `data` as the parameter of the callback.

Fixes the warnings:

```
[36/45] Generating libportal/Xdp-1.0.gir with a custom command (wrapped by meson to set env)
../libportal/account.c:209: Warning: Xdp: invalid "closure" annotation: only valid on callback parameters
../libportal/background.c:329: Warning: Xdp: invalid "closure" annotation: only valid on callback parameters
../libportal/background.c:399: Warning: Xdp: invalid "closure" annotation: only valid on callback parameters
../libportal/camera.c:218: Warning: Xdp: invalid "closure" annotation: only valid on callback parameters
../libportal/dynamic-launcher.c:236: Warning: Xdp: invalid "closure" annotation: only valid on callback parameters
../libportal/email.c:308: Warning: Xdp: invalid "closure" annotation: only valid on callback parameters
../libportal/filechooser.c:245: Warning: Xdp: invalid "closure" annotation: only valid on callback parameters
../libportal/filechooser.c:353: Warning: Xdp: invalid "closure" annotation: only valid on callback parameters
../libportal/filechooser.c:446: Warning: Xdp: invalid "closure" annotation: only valid on callback parameters
../libportal/inhibit.c:218: Warning: Xdp: invalid "closure" annotation: only valid on callback parameters
../libportal/inhibit.c:569: Warning: Xdp: invalid "closure" annotation: only valid on callback parameters
../libportal/inputcapture.c:727: Warning: Xdp: invalid "closure" annotation: only valid on callback parameters
../libportal/location.c:330: Warning: Xdp: invalid "closure" annotation: only valid on callback parameters
../libportal/notification.c:723: Warning: Xdp: invalid "closure" annotation: only valid on callback parameters
../libportal/openuri.c:277: Warning: Xdp: invalid "closure" annotation: only valid on callback parameters
../libportal/openuri.c:344: Warning: Xdp: invalid "closure" annotation: only valid on callback parameters
../libportal/print.c:280: Warning: Xdp: invalid "closure" annotation: only valid on callback parameters
../libportal/print.c:358: Warning: Xdp: invalid "closure" annotation: only valid on callback parameters
../libportal/remote.c:460: Warning: Xdp: invalid "closure" annotation: only valid on callback parameters
../libportal/remote.c:530: Warning: Xdp: invalid "closure" annotation: only valid on callback parameters
../libportal/remote.c:570: Warning: Xdp: invalid "closure" annotation: only valid on callback parameters
../libportal/remote.c:808: Warning: Xdp: invalid "closure" annotation: only valid on callback parameters
../libportal/screenshot.c:224: Warning: Xdp: invalid "closure" annotation: only valid on callback parameters
../libportal/screenshot.c:288: Warning: Xdp: invalid "closure" annotation: only valid on callback parameters
../libportal/spawn.c:203: Warning: Xdp: invalid "closure" annotation: only valid on callback parameters
../libportal/trash.c:128: Warning: Xdp: invalid "closure" annotation: only valid on callback parameters
../libportal/updates.c:208: Warning: Xdp: invalid "closure" annotation: only valid on callback parameters
../libportal/updates.c:391: Warning: Xdp: invalid "closure" annotation: only valid on callback parameters
../libportal/wallpaper.c:286: Warning: Xdp: invalid "closure" annotation: only valid on callback parameters
```

