### PR TITLE
Add API to register app ID

### DIFF
--- a/libportal/portal-helpers.h
+++ b/libportal/portal-helpers.h
@@ -46,6 +46,18 @@ XDP_PUBLIC
 XdpPortal *xdp_portal_initable_new          (GError **error);
 
 XDP_PUBLIC
+void       xdp_portal_register              (XdpPortal           *portal,
+                                             const char          *app_id,
+                                             GCancellable        *cancellable,
+                                             GAsyncReadyCallback  callback,
+                                             gpointer             user_data);
+
+XDP_PUBLIC
+gboolean   xdp_portal_register_finish       (XdpPortal           *portal,
+                                             GAsyncResult        *result,
+                                             GError             **error);
+
+XDP_PUBLIC
 gboolean   xdp_portal_running_under_flatpak (void);
 
 XDP_PUBLIC

--- a/portal-test/gtk4/application.js
+++ b/portal-test/gtk4/application.js
@@ -1,4 +1,4 @@
-const { Gio, GLib, GObject, Gtk } = imports.gi;
+const { Gio, GLib, GObject, Gtk, Xdp } = imports.gi;
 
 const { PortalTestWindow } = imports.window;
 const ByteArray = imports.byteArray;
@@ -31,10 +31,19 @@ var Application = GObject.registerClass({
     }
 
     vfunc_startup() {
+        this._portal = new Xdp.Portal();
+        this._portal.register(this.get_application_id(), null, (portal, result) => {
+          this._portal.register_finish(result);
+        });
+
         super.vfunc_startup();
 
         if (!this._window)
             this._window = new PortalTestWindow(this);
+    }
+
+    getPortal() {
+        return this._portal;
     }
 
     restart() {

--- a/portal-test/gtk4/window.js
+++ b/portal-test/gtk4/window.js
@@ -37,7 +37,7 @@ var PortalTestWindow = GObject.registerClass({
         super._init({ application });
 
         this._app = application;
-        this._portal = new Xdp.Portal();
+        this._portal = application.getPortal();
 
         this._restoreToken = null;
 

--- a/portal-test/qt5/main.cpp
+++ b/portal-test/qt5/main.cpp
@@ -3,11 +3,15 @@
 
 #include "portal-test-qt.h"
 
+#define APP_ID "org.freedesktop.PortalTest.Qt5"
+
 int main(int argc, char *argv[])
 {
     QApplication a(argc, argv);
 
-    PortalTestQt *portalTest = new PortalTestQt(nullptr);
+    a.setDesktopFileName(APP_ID);
+
+    PortalTestQt *portalTest = new PortalTestQt(&a, nullptr);
     portalTest->show();
 
     return a.exec();

--- a/portal-test/qt5/meson.build
+++ b/portal-test/qt5/meson.build
@@ -14,6 +14,8 @@ prep = qt5.preprocess(
   dependencies: libportal_qt5_dep,
 )
 
+install_data('org.freedesktop.PortalTest.Qt5.desktop', install_dir: 'share/applications')
+
 executable('portal-test-qt5',
   [src, prep],
   include_directories: [top_inc, libportal_inc],

--- a/portal-test/qt5/org.freedesktop.PortalTest.Qt5.desktop
+++ b/portal-test/qt5/org.freedesktop.PortalTest.Qt5.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=Portal test (GTK3)
+Exec=portal-test-gtk3
+Type=Application
+DBusActivatable=true

--- a/portal-test/qt5/portal-test-qt.h
+++ b/portal-test/qt5/portal-test-qt.h
@@ -14,7 +14,7 @@ class PortalTestQt : public QMainWindow
 {
     Q_OBJECT
 public:
-    PortalTestQt(QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
+    PortalTestQt(QApplication *app, QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
     ~PortalTestQt();
 
     void updateLastOpenedFile(const QString &file);
@@ -22,6 +22,7 @@ private:
     static void openedFile(GObject *object, GAsyncResult *result, gpointer data);
 
     Ui_PortalTestQt *m_mainWindow;
+    QApplication *m_app;
     XdpPortal *m_portal;
 };
 

--- a/portal-test/qt6/main.cpp
+++ b/portal-test/qt6/main.cpp
@@ -3,11 +3,33 @@
 
 #include "portal-test-qt.h"
 
+#define APP_ID "org.gnome.PortalTest.Qt6"
+
+
 int main(int argc, char *argv[])
 {
-    QApplication a(argc, argv);
+    XdpPortal *portal = xdp_portal_new();
+    xdp_portal_register(portal, APP_ID, nullptr /*cancellable*/,
+                        [](GObject *source_object, GAsyncResult *result, gpointer user_data)
+                        {
+                          Q_UNUSED(user_data)
 
-    PortalTestQt *portalTest = new PortalTestQt(nullptr);
+                          XdpPortal *portal = XDP_PORTAL (source_object);
+                          g_autoptr(GError) error = NULL;
+                          if (!xdp_portal_register_finish (portal, result, &error))
+                          {
+                              if (!g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
+                                  qWarning ("Failed to register application ID: %s", error->message);
+                              return;
+                          }
+
+                          qInfo ("Registered application ID");
+                        },
+                        nullptr);
+
+
+    QApplication a(argc, argv);
+    PortalTestQt *portalTest = new PortalTestQt(portal, nullptr);
     portalTest->show();
 
     return a.exec();

--- a/portal-test/qt6/meson.build
+++ b/portal-test/qt6/meson.build
@@ -14,6 +14,8 @@ prep = qt6.preprocess(
   dependencies: libportal_qt6_dep,
 )
 
+install_data('org.freedesktop.PortalTest.Qt6.desktop', install_dir: 'share/applications')
+
 executable('portal-test-qt6',
   [src, prep],
   include_directories: [top_inc, libportal_inc],

--- a/portal-test/qt6/org.freedesktop.PortalTest.Qt6.desktop
+++ b/portal-test/qt6/org.freedesktop.PortalTest.Qt6.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=Portal test (GTK3)
+Exec=portal-test-gtk3
+Type=Application
+DBusActivatable=true

--- a/portal-test/qt6/portal-test-qt.cpp
+++ b/portal-test/qt6/portal-test-qt.cpp
@@ -4,10 +4,10 @@
 
 #include <QStringLiteral>
 
-PortalTestQt::PortalTestQt(QWidget *parent, Qt::WindowFlags f)
+PortalTestQt::PortalTestQt(XdpPortal *portal, QWidget *parent, Qt::WindowFlags f)
     : QMainWindow(parent, f)
     , m_mainWindow(new Ui_PortalTestQt)
-    , m_portal(xdp_portal_new())
+    , m_portal(portal)
 {
     m_mainWindow->setupUi(this);
 

--- a/portal-test/qt6/portal-test-qt.h
+++ b/portal-test/qt6/portal-test-qt.h
@@ -14,7 +14,7 @@ class PortalTestQt : public QMainWindow
 {
     Q_OBJECT
 public:
-    PortalTestQt(QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
+    PortalTestQt(XdpPortal *portal, QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
     ~PortalTestQt();
 
     void updateLastOpenedFile(const QString &file);


### PR DESCRIPTION
Meant to be used by host apps to more reliably get an app ID. See https://github.com/flatpak/xdg-desktop-portal/pull/1521.