### PR TITLE
Fix type of signal IDs, make disconnection more obviously correct

### DIFF
--- a/libportal/account.c
+++ b/libportal/account.c
@@ -30,7 +30,7 @@ typedef struct {
   GTask *task;
   guint signal_id;
   char *request_path;
-  guint cancelled_id;
+  gulong cancelled_id;
 } AccountCall;
 
 static void

--- a/libportal/account.c
+++ b/libportal/account.c
@@ -47,8 +47,7 @@ account_call_free (AccountCall *call)
   if (call->signal_id)
     g_dbus_connection_signal_unsubscribe (call->portal->bus, call->signal_id);
 
-  if (call->cancelled_id)
-    g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
+  g_clear_signal_handler (&call->cancelled_id, g_task_get_cancellable (call->task));
 
   g_free (call->request_path);
 
@@ -73,11 +72,7 @@ response_received (GDBusConnection *bus,
   guint32 response;
   g_autoptr(GVariant) ret = NULL;
 
-  if (call->cancelled_id)
-    {
-      g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
-      call->cancelled_id = 0;
-    }
+  g_clear_signal_handler (&call->cancelled_id, g_task_get_cancellable (call->task));
 
   g_variant_get (parameters, "(u@a{sv})", &response, &ret);
 
@@ -138,12 +133,7 @@ call_returned (GObject *object,
   ret = g_dbus_connection_call_finish (bus, result, &error);
   if (error)
     {
-      if (call->cancelled_id)
-        {
-          g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
-          call->cancelled_id = 0;
-        }
-
+      g_clear_signal_handler (&call->cancelled_id, g_task_get_cancellable (call->task));
       g_task_return_error (call->task, error);
       account_call_free (call);
     }

--- a/libportal/background.c
+++ b/libportal/background.c
@@ -137,7 +137,7 @@ typedef struct {
   guint signal_id;
   GTask *task;
   char *request_path;
-  guint cancelled_id;
+  gulong cancelled_id;
 
   gboolean autostart;
   gboolean dbus_activatable;

--- a/libportal/background.c
+++ b/libportal/background.c
@@ -158,8 +158,7 @@ background_call_free (BackgroundCall *call)
   if (call->signal_id)
     g_dbus_connection_signal_unsubscribe (call->portal->bus, call->signal_id);
 
-  if (call->cancelled_id)
-    g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
+  g_clear_signal_handler (&call->cancelled_id, g_task_get_cancellable (call->task));
 
   g_free (call->request_path);
 
@@ -185,11 +184,7 @@ response_received (GDBusConnection *bus,
   guint32 response;
   g_autoptr(GVariant) ret = NULL;
 
-  if (call->cancelled_id)
-    {
-      g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
-      call->cancelled_id = 0;
-    }
+  g_clear_signal_handler (&call->cancelled_id, g_task_get_cancellable (call->task));
 
   g_variant_get (parameters, "(u@a{sv})", &response, &ret);
 
@@ -251,12 +246,7 @@ call_returned (GObject *object,
   ret = g_dbus_connection_call_finish (G_DBUS_CONNECTION (object), result, &error);
   if (error)
     {
-      if (call->cancelled_id)
-        {
-          g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
-          call->cancelled_id = 0;
-        }
-
+      g_clear_signal_handler (&call->cancelled_id, g_task_get_cancellable (call->task));
       g_task_return_error (call->task, error);
       background_call_free (call);
     }

--- a/libportal/camera.c
+++ b/libportal/camera.c
@@ -69,7 +69,7 @@ typedef struct {
   GCancellable *cancellable;
   GTask *task;
   char *request_path;
-  guint cancelled_id;
+  gulong cancelled_id;
 } AccessCameraCall;
 
 static void

--- a/libportal/camera.c
+++ b/libportal/camera.c
@@ -78,8 +78,7 @@ access_camera_call_free (AccessCameraCall *call)
   if (call->signal_id)
     g_dbus_connection_signal_unsubscribe (call->portal->bus, call->signal_id);
 
-  if (call->cancelled_id)
-    g_signal_handler_disconnect (call->cancellable, call->cancelled_id);
+  g_clear_signal_handler (&call->cancelled_id, call->cancellable);
 
   g_free (call->request_path);
 
@@ -104,11 +103,7 @@ response_received (GDBusConnection *bus,
   guint32 response;
   g_autoptr(GVariant) ret = NULL;
 
-  if (call->cancelled_id)
-    {
-      g_signal_handler_disconnect (call->cancellable, call->cancelled_id);
-      call->cancelled_id = 0;
-    }
+  g_clear_signal_handler (&call->cancelled_id, call->cancellable);
 
   g_variant_get (parameters, "(u@a{sv})", &response, &ret);
 
@@ -157,12 +152,7 @@ call_returned (GObject *object,
   ret = g_dbus_connection_call_finish (G_DBUS_CONNECTION (object), result, &error);
   if (error)
     {
-      if (call->cancelled_id)
-        {
-          g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
-          call->cancelled_id = 0;
-        }
-
+      g_clear_signal_handler (&call->cancelled_id, call->cancellable);
       g_task_return_error (call->task, error);
       access_camera_call_free (call);
     }

--- a/libportal/dynamic-launcher.c
+++ b/libportal/dynamic-launcher.c
@@ -62,8 +62,7 @@ prepare_install_launcher_call_free (PrepareInstallLauncherCall *call)
   if (call->signal_id)
     g_dbus_connection_signal_unsubscribe (call->portal->bus, call->signal_id);
 
-  if (call->cancelled_id)
-    g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
+  g_clear_signal_handler (&call->cancelled_id, g_task_get_cancellable (call->task));
 
   g_free (call->request_path);
 
@@ -90,11 +89,7 @@ response_received (GDBusConnection *bus,
   guint32 response;
   g_autoptr(GVariant) ret = NULL;
 
-  if (call->cancelled_id)
-    {
-      g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
-      call->cancelled_id = 0;
-    }
+  g_clear_signal_handler (&call->cancelled_id, g_task_get_cancellable (call->task));
 
   g_variant_get (parameters, "(u@a{sv})", &response, &ret);
 
@@ -155,11 +150,7 @@ prepare_install_returned (GObject      *object,
   ret = g_dbus_connection_call_finish (G_DBUS_CONNECTION (object), result, &error);
   if (error)
     {
-      if (call->cancelled_id)
-        {
-          g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
-          call->cancelled_id = 0;
-        }
+      g_clear_signal_handler (&call->cancelled_id, g_task_get_cancellable (call->task));
       g_task_return_error (call->task, error);
       prepare_install_launcher_call_free (call);
     }

--- a/libportal/dynamic-launcher.c
+++ b/libportal/dynamic-launcher.c
@@ -46,7 +46,7 @@ typedef struct {
   guint signal_id;
   GTask *task;
   char *request_path;
-  guint cancelled_id;
+  gulong cancelled_id;
 } PrepareInstallLauncherCall;
 
 static void

--- a/libportal/email.c
+++ b/libportal/email.c
@@ -48,7 +48,7 @@ typedef struct {
   guint signal_id;
   GTask *task;
   char *request_path;
-  guint cancelled_id;
+  gulong cancelled_id;
 } EmailCall;
 
 static void

--- a/libportal/filechooser.c
+++ b/libportal/filechooser.c
@@ -55,9 +55,7 @@ file_call_free (FileCall *call)
   if (call->signal_id)
     g_dbus_connection_signal_unsubscribe (call->portal->bus, call->signal_id);
 
-  if (call->cancelled_id)
-    g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
-
+  g_clear_signal_handler (&call->cancelled_id, g_task_get_cancellable (call->task));
   g_free (call->request_path);
 
   g_object_unref (call->portal);
@@ -93,11 +91,7 @@ response_received (GDBusConnection *bus,
   guint32 response;
   g_autoptr(GVariant) ret = NULL;
 
-  if (call->cancelled_id)
-    {
-      g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
-      call->cancelled_id = 0;
-    }
+  g_clear_signal_handler (&call->cancelled_id, g_task_get_cancellable (call->task));
 
   g_variant_get (parameters, "(u@a{sv})", &response, &ret);
 
@@ -157,12 +151,7 @@ call_returned (GObject *object,
   ret = g_dbus_connection_call_finish (G_DBUS_CONNECTION (object), result, &error);
   if (error)
     {
-      if (call->cancelled_id)
-        {
-          g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
-          call->cancelled_id = 0;
-        }
-
+      g_clear_signal_handler (&call->cancelled_id, g_task_get_cancellable (call->task));
       g_task_return_error (call->task, error);
       file_call_free (call);
     }

--- a/libportal/filechooser.c
+++ b/libportal/filechooser.c
@@ -39,7 +39,7 @@ typedef struct {
   guint signal_id;
   GTask *task;
   char *request_path;
-  guint cancelled_id;
+  gulong cancelled_id;
 } FileCall;
 
 static void

--- a/libportal/inhibit.c
+++ b/libportal/inhibit.c
@@ -28,7 +28,7 @@ typedef struct {
   char *parent_handle;
   XdpInhibitFlags inhibit;
   guint signal_id;
-  guint cancelled_id;
+  gulong cancelled_id;
   char *request_path;
   char *reason;
   GTask *task;
@@ -336,7 +336,7 @@ typedef struct {
   GTask *task;
   char *request_path;
   guint signal_id;
-  guint cancelled_id;
+  gulong cancelled_id;
   char *id;
 } CreateMonitorCall;
 

--- a/libportal/inputcapture.c
+++ b/libportal/inputcapture.c
@@ -220,7 +220,7 @@ typedef struct {
   GTask *task;
   guint signal_id; /* Request::Response signal */
   char *request_path; /* object path for request */
-  guint cancelled_id; /* signal id for cancelled gobject signal */
+  gulong cancelled_id; /* signal id for cancelled gobject signal */
 
   /* CreateSession only */
   XdpParent *parent;

--- a/libportal/inputcapture.c
+++ b/libportal/inputcapture.c
@@ -253,8 +253,7 @@ call_free (Call *call)
   if (call->signal_id)
     g_dbus_connection_signal_unsubscribe (call->portal->bus, call->signal_id);
 
-  if (call->cancelled_id)
-    g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
+  g_clear_signal_handler (&call->cancelled_id, g_task_get_cancellable (call->task));
 
   g_free (call->request_path);
 
@@ -279,11 +278,7 @@ call_returned (GObject *object,
   ret = g_dbus_connection_call_finish (G_DBUS_CONNECTION (object), result, &error);
   if (error)
     {
-      if (call->cancelled_id)
-        {
-          g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
-          call->cancelled_id = 0;
-        }
+      g_clear_signal_handler (&call->cancelled_id, g_task_get_cancellable (call->task));
       g_task_return_error (call->task, error);
       call_free (call);
     }
@@ -495,11 +490,8 @@ get_zones_done (GDBusConnection *bus,
 
   g_variant_get (parameters, "(u@a{sv})", &response, &ret);
 
-  if (response != 0 && call->cancelled_id)
-    {
-      g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
-      call->cancelled_id = 0;
-    }
+  if (response != 0)
+    g_clear_signal_handler (&call->cancelled_id, g_task_get_cancellable (call->task));
 
   if (response == 0)
     {
@@ -624,11 +616,8 @@ session_created (GDBusConnection *bus,
 
   g_variant_get (parameters, "(u@a{sv})", &response, &ret);
 
-  if (response != 0 && call->cancelled_id)
-    {
-      g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
-      call->cancelled_id = 0;
-    }
+  if (response != 0)
+    g_clear_signal_handler (&call->cancelled_id, g_task_get_cancellable (call->task));
 
   if (response == 0)
     {

--- a/libportal/location.c
+++ b/libportal/location.c
@@ -31,7 +31,7 @@ typedef struct {
   guint signal_id;
   GTask *task;
   char *request_path;
-  guint cancelled_id;
+  gulong cancelled_id;
   int distance;
   int time;
   XdpLocationAccuracy accuracy;

--- a/libportal/location.c
+++ b/libportal/location.c
@@ -50,8 +50,7 @@ create_call_free (CreateCall *call)
   if (call->signal_id)
     g_dbus_connection_signal_unsubscribe (call->portal->bus, call->signal_id);
 
-  if (call->cancelled_id)
-    g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
+  g_clear_signal_handler (&call->cancelled_id, g_task_get_cancellable (call->task));
 
   g_free (call->request_path);
 
@@ -76,11 +75,7 @@ session_started (GDBusConnection *bus,
   guint32 response;
   g_autoptr(GVariant) ret = NULL;
 
-  if (call->cancelled_id)
-    {
-      g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
-      call->cancelled_id = 0;
-    }
+  g_clear_signal_handler (&call->cancelled_id, g_task_get_cancellable (call->task));
 
   g_variant_get (parameters, "(u@a{sv})", &response, &ret);
 
@@ -188,12 +183,7 @@ call_returned (GObject *object,
   ret = g_dbus_connection_call_finish (G_DBUS_CONNECTION (object), result, &error);
   if (error)
     {
-      if (call->cancelled_id)
-        {
-          g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
-          call->cancelled_id = 0;
-        }
-
+      g_clear_signal_handler (&call->cancelled_id, g_task_get_cancellable (call->task));
       g_task_return_error (call->task, error);
       create_call_free (call);
     }

--- a/libportal/openuri.c
+++ b/libportal/openuri.c
@@ -43,7 +43,7 @@ typedef struct {
   guint signal_id;
   GTask *task;
   char *request_path;
-  guint cancelled_id;
+  gulong cancelled_id;
 } OpenCall;
 
 static void

--- a/libportal/print.c
+++ b/libportal/print.c
@@ -48,7 +48,7 @@ typedef struct {
   guint signal_id;
   GTask *task;
   char *request_path;
-  guint cancelled_id;
+  gulong cancelled_id;
 } PrintCall;
 
 static void

--- a/libportal/print.c
+++ b/libportal/print.c
@@ -64,8 +64,7 @@ print_call_free (PrintCall *call)
   if (call->signal_id)
     g_dbus_connection_signal_unsubscribe (call->portal->bus, call->signal_id);
 
-  if (call->cancelled_id)
-    g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
+  g_clear_signal_handler (&call->cancelled_id, g_task_get_cancellable (call->task));
 
   g_free (call->request_path);
 
@@ -95,11 +94,7 @@ response_received (GDBusConnection *bus,
   guint32 response;
   g_autoptr(GVariant) ret = NULL;
 
-  if (call->cancelled_id)
-    {
-      g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
-      call->cancelled_id = 0;
-    }
+  g_clear_signal_handler (&call->cancelled_id, g_task_get_cancellable (call->task));
 
   g_variant_get (parameters, "(u@a{sv})", &response, &ret);
 
@@ -167,12 +162,7 @@ call_returned (GObject *object,
     ret = g_dbus_connection_call_with_unix_fd_list_finish (G_DBUS_CONNECTION (object), NULL, result, &error);
   if (error)
     {
-      if (call->cancelled_id)
-        {
-          g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
-          call->cancelled_id = 0;
-        }
-
+      g_clear_signal_handler (&call->cancelled_id, g_task_get_cancellable (call->task));
       g_task_return_error (call->task, error);
       print_call_free (call);
     }

--- a/libportal/remote.c
+++ b/libportal/remote.c
@@ -47,8 +47,7 @@ create_call_free (CreateCall *call)
   if (call->signal_id)
     g_dbus_connection_signal_unsubscribe (call->portal->bus, call->signal_id);
 
-  if (call->cancelled_id)
-    g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
+  g_clear_signal_handler (&call->cancelled_id, g_task_get_cancellable (call->task));
 
   g_free (call->request_path);
   g_free (call->restore_token);
@@ -74,11 +73,7 @@ sources_selected (GDBusConnection *bus,
   guint32 response;
   g_autoptr(GVariant) ret = NULL;
 
-  if (call->cancelled_id)
-    {
-      g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
-      call->cancelled_id = 0;
-    }
+  g_clear_signal_handler (&call->cancelled_id, g_task_get_cancellable (call->task));
 
   g_variant_get (parameters, "(u@a{sv})", &response, &ret);
 
@@ -109,12 +104,7 @@ call_returned (GObject *object,
   ret = g_dbus_connection_call_finish (G_DBUS_CONNECTION (object), result, &error);
   if (error)
     {
-      if (call->cancelled_id)
-        {
-          g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
-          call->cancelled_id = 0;
-        }
-
+      g_clear_signal_handler (&call->cancelled_id, g_task_get_cancellable (call->task));
       g_task_return_error (call->task, error);
       create_call_free (call);
     }
@@ -180,11 +170,8 @@ devices_selected (GDBusConnection *bus,
 
   g_variant_get (parameters, "(u@a{sv})", &response, &ret);
 
-  if (response != 0 && call->cancelled_id)
-    {
-      g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
-      call->cancelled_id = 0;
-    }
+  if (response != 0)
+    g_clear_signal_handler (&call->cancelled_id, g_task_get_cancellable (call->task));
 
   if (response == 0)
     {
@@ -195,12 +182,7 @@ devices_selected (GDBusConnection *bus,
         select_sources (call);
       else
         {
-          if (call->cancelled_id)
-            {
-              g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
-              call->cancelled_id = 0;
-            }
-
+          g_clear_signal_handler (&call->cancelled_id, g_task_get_cancellable (call->task));
           g_task_return_pointer (call->task, _xdp_session_new (call->portal, call->id, call->type), g_object_unref);
           create_call_free (call);
         }
@@ -272,11 +254,8 @@ session_created (GDBusConnection *bus,
 
   g_variant_get (parameters, "(u@a{sv})", &response, &ret);
 
-  if (response != 0 && call->cancelled_id)
-    {
-      g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
-      call->cancelled_id = 0;
-    }
+  if (response != 0)
+    g_clear_signal_handler (&call->cancelled_id, g_task_get_cancellable (call->task));
 
   if (response == 0)
     {
@@ -654,8 +633,7 @@ start_call_free (StartCall *call)
   if (call->signal_id)
     g_dbus_connection_signal_unsubscribe (call->portal->bus, call->signal_id);
 
-  if (call->cancelled_id)
-    g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
+  g_clear_signal_handler (&call->cancelled_id, g_task_get_cancellable (call->task));
 
   g_free (call->request_path);
 
@@ -679,11 +657,7 @@ session_started (GDBusConnection *bus,
   guint32 response;
   g_autoptr(GVariant) ret = NULL;
 
-  if (call->cancelled_id)
-    {
-      g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
-      call->cancelled_id = 0;
-    }
+  g_clear_signal_handler (&call->cancelled_id, g_task_get_cancellable (call->task));
 
   g_variant_get (parameters, "(u@a{sv})", &response, &ret);
 

--- a/libportal/remote.c
+++ b/libportal/remote.c
@@ -38,7 +38,7 @@ typedef struct {
   guint signal_id;
   GTask *task;
   char *request_path;
-  guint cancelled_id;
+  gulong cancelled_id;
 } CreateCall;
 
 static void
@@ -638,7 +638,7 @@ typedef struct {
   guint signal_id;
   GTask *task;
   char *request_path;
-  guint cancelled_id;
+  gulong cancelled_id;
 } StartCall;
 
 static void

--- a/libportal/screenshot.c
+++ b/libportal/screenshot.c
@@ -31,7 +31,7 @@ typedef struct {
   guint signal_id;
   GTask *task;
   char *request_path;
-  guint cancelled_id;
+  gulong cancelled_id;
 } ScreenshotCall;
 
 static void

--- a/libportal/screenshot.c
+++ b/libportal/screenshot.c
@@ -47,8 +47,7 @@ screenshot_call_free (ScreenshotCall *call)
   if (call->signal_id)
     g_dbus_connection_signal_unsubscribe (call->portal->bus, call->signal_id);
 
-  if (call->cancelled_id)
-    g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
+  g_clear_signal_handler (&call->cancelled_id, g_task_get_cancellable (call->task));
 
   g_free (call->request_path);
 
@@ -71,11 +70,7 @@ response_received (GDBusConnection *bus,
   guint32 response;
   g_autoptr(GVariant) ret = NULL;
 
-  if (call->cancelled_id)
-    {
-      g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
-      call->cancelled_id = 0;
-    }
+  g_clear_signal_handler (&call->cancelled_id, g_task_get_cancellable (call->task));
 
   g_variant_get (parameters, "(u@a{sv})", &response, &ret);
 
@@ -154,12 +149,7 @@ call_returned (GObject *object,
   ret = g_dbus_connection_call_finish (G_DBUS_CONNECTION (object), result, &error);
   if (error)
     {
-      if (call->cancelled_id)
-        {
-          g_signal_handler_disconnect (g_task_get_cancellable (call->task), call->cancelled_id);
-          call->cancelled_id = 0;
-        }
-
+      g_clear_signal_handler (&call->cancelled_id, g_task_get_cancellable (call->task));
       g_task_return_error (call->task, error);
       screenshot_call_free (call);
     }

--- a/libportal/wallpaper.c
+++ b/libportal/wallpaper.c
@@ -42,7 +42,7 @@ typedef struct {
   guint signal_id;
   GTask *task;
   char *request_path;
-  guint cancelled_id;
+  gulong cancelled_id;
 } WallpaperCall;
 
 static void


### PR DESCRIPTION
* Fix type used for signal IDs
    
    While trying to investigate #169 I noticed that inputcapture was using
    guint instead of the correct gulong for GObject signal IDs, which could
    conceivably result in a signal ID being truncated and the wrong signal
    being disconnected (although in practice signal IDs are allocated
    starting from 0, so this is unlikely). The same pattern is seen in all
    of the other portals.
    
    Using the correct type also allows g_clear_signal_handler() to be used,
    for idempotent signal disconnections.

* Consistently use g_clear_signal_handler to disconnect GObject signals
    
    This is more concise than writing out equivalent code every time,
    and ensures that signal disconnection is idempotent and that the correct
    type (gulong) is always used for the signal ID.