### PR TITLE
Assert we only free a Call at an appropriate point in its life cycle

### DIFF
--- a/libportal/account.c
+++ b/libportal/account.c
@@ -36,6 +36,8 @@ typedef struct {
 static void
 account_call_free (AccountCall *call)
 {
+  g_return_if_fail (G_IS_TASK (call->task));
+
   g_debug ("freeing AccountCall");
   if (call->parent)
     {

--- a/libportal/background.c
+++ b/libportal/background.c
@@ -33,6 +33,8 @@ typedef struct {
 static void
 set_status_call_free (SetStatusCall *call)
 {
+  g_return_if_fail (G_IS_TASK (call->task));
+
   g_clear_pointer (&call->status_message, g_free);
   g_clear_object (&call->portal);
   g_clear_object (&call->task);
@@ -148,6 +150,8 @@ typedef struct {
 static void
 background_call_free (BackgroundCall *call)
 {
+  g_return_if_fail (G_IS_TASK (call->task));
+
   if (call->parent)
     {
       call->parent->parent_unexport (call->parent);

--- a/libportal/camera.c
+++ b/libportal/camera.c
@@ -75,6 +75,8 @@ typedef struct {
 static void
 access_camera_call_free (AccessCameraCall *call)
 {
+  g_return_if_fail (G_IS_TASK (call->task));
+
   if (call->signal_id)
     g_dbus_connection_signal_unsubscribe (call->portal->bus, call->signal_id);
 

--- a/libportal/dynamic-launcher.c
+++ b/libportal/dynamic-launcher.c
@@ -52,6 +52,8 @@ typedef struct {
 static void
 prepare_install_launcher_call_free (PrepareInstallLauncherCall *call)
 {
+  g_return_if_fail (G_IS_TASK (call->task));
+
   if (call->parent)
     {
       call->parent->parent_unexport (call->parent);

--- a/libportal/email.c
+++ b/libportal/email.c
@@ -54,6 +54,8 @@ typedef struct {
 static void
 email_call_free (EmailCall *call)
 {
+  g_return_if_fail (G_IS_TASK (call->task));
+
   if (call->parent)
     {
       call->parent->parent_unexport (call->parent);

--- a/libportal/filechooser.c
+++ b/libportal/filechooser.c
@@ -45,6 +45,8 @@ typedef struct {
 static void
 file_call_free (FileCall *call)
 {
+  g_return_if_fail (G_IS_TASK (call->task));
+
   if (call->parent)
     {
       call->parent->parent_unexport (call->parent);

--- a/libportal/inhibit.c
+++ b/libportal/inhibit.c
@@ -38,6 +38,8 @@ typedef struct {
 static void
 inhibit_call_free (InhibitCall *call)
 {
+  g_return_if_fail (G_IS_TASK (call->task));
+
   if (call->parent)
     {
       call->parent->parent_unexport (call->parent);

--- a/libportal/inputcapture.c
+++ b/libportal/inputcapture.c
@@ -241,6 +241,8 @@ static void get_zones (Call *call);
 static void
 call_free (Call *call)
 {
+  g_return_if_fail (G_IS_TASK (call->task));
+
   /* CreateSesssion */
   if (call->parent)
     {

--- a/libportal/location.c
+++ b/libportal/location.c
@@ -40,6 +40,8 @@ typedef struct {
 static void
 create_call_free (CreateCall *call)
 {
+  g_return_if_fail (G_IS_TASK (call->task));
+
   if (call->parent)
     {
       call->parent->parent_unexport (call->parent);

--- a/libportal/openuri.c
+++ b/libportal/openuri.c
@@ -49,6 +49,8 @@ typedef struct {
 static void
 open_call_free (OpenCall *call)
 {
+  g_return_if_fail (G_IS_TASK (call->task));
+
   if (call->parent)
     {
       call->parent->parent_unexport (call->parent);

--- a/libportal/print.c
+++ b/libportal/print.c
@@ -54,6 +54,8 @@ typedef struct {
 static void
 print_call_free (PrintCall *call)
 {
+  g_return_if_fail (G_IS_TASK (call->task));
+
   if (call->parent)
     {
       call->parent->parent_unexport (call->parent);

--- a/libportal/remote.c
+++ b/libportal/remote.c
@@ -44,6 +44,8 @@ typedef struct {
 static void
 create_call_free (CreateCall *call)
 {
+  g_return_if_fail (G_IS_TASK (call->task));
+
   if (call->signal_id)
     g_dbus_connection_signal_unsubscribe (call->portal->bus, call->signal_id);
 

--- a/libportal/screenshot.c
+++ b/libportal/screenshot.c
@@ -37,6 +37,8 @@ typedef struct {
 static void
 screenshot_call_free (ScreenshotCall *call)
 {
+  g_return_if_fail (G_IS_TASK (call->task));
+
   if (call->parent)
     {
       call->parent->parent_unexport (call->parent);

--- a/libportal/spawn.c
+++ b/libportal/spawn.c
@@ -50,6 +50,8 @@ typedef struct {
 static void
 spawn_call_free (SpawnCall *call)
 {
+  g_return_if_fail (G_IS_TASK (call->task));
+
   g_object_unref (call->portal);
   g_object_unref (call->task);
 

--- a/libportal/trash.c
+++ b/libportal/trash.c
@@ -41,6 +41,8 @@ typedef struct {
 static void
 trash_call_free (TrashCall *call)
 {
+  g_return_if_fail (G_IS_TASK (call->task));
+
   g_object_unref (call->portal);
   g_object_unref (call->task);
   g_free (call->path);

--- a/libportal/updates.c
+++ b/libportal/updates.c
@@ -35,6 +35,8 @@ typedef struct {
 static void
 create_monitor_call_free (CreateMonitorCall *call)
 {
+  g_return_if_fail (G_IS_TASK (call->task));
+
   g_free (call->request_path);
   g_free (call->id);
 

--- a/libportal/wallpaper.c
+++ b/libportal/wallpaper.c
@@ -48,6 +48,8 @@ typedef struct {
 static void
 wallpaper_call_free (WallpaperCall *call)
 {
+  g_return_if_fail (G_IS_TASK (call->task));
+
   if (call->parent)
     {
       call->parent->parent_unexport (call->parent);


### PR DESCRIPTION
* Assert that we only free a Call at an appropriate point in its life cycle
    
    Each Call wraps a single GTask, which is created along with the Call and
    cleared when the Call is destroyed. If the Call has become invalid, that
    would indicate a use-after-free similar to #169, or some other memory
    corruption.

---

On a cloud VM instance that was being used for Debian QA, where (for whatever reason) #169 seems to happen much more often than on the official autobuilders or my own system, this replaces the segfault seen in #169 with an assertion failure: the GTask is no longer a valid object pointer (in fact it happens to be null).