### PR TITLE
tests: Run pytest with G_DEBUG=fatal-criticals

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -14,6 +14,7 @@ if meson.version().version_compare('>= 0.56.0')
     test_env = environment()
     test_env.set('LD_LIBRARY_PATH', meson.project_build_root() / 'libportal')
     test_env.set('GI_TYPELIB_PATH', meson.project_build_root() / 'libportal')
+    test_env.set('G_DEBUG', 'fatal-criticals')
 
     test('pytest',
       pytest,


### PR DESCRIPTION
This ensures that we crash out at any sign of undefined behaviour. This is the default for GLib's own GTest framework, but not for other test frameworks like pytest.

Note that we cannot use fatal-warnings (which would be the default for GTest) because at least one test-case for the inputcapture portal emulates a faulty portal implementation, which libportal will log as a g_warning().