### PR TITLE
.gitignore: Ignore all __pycache__ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.flatpak-builder/
 /_build/
+__pycache__/


### PR DESCRIPTION
The pytest-based test suite generates these in tests/pyportaltest/ and tests/pyportaltest/templates/ in the source directory, not the build directory.