### PR TITLE
inputcapture: Reference-count Call objects

### DIFF
--- a/libportal/glib-backports.h
+++ b/libportal/glib-backports.h
@@ -65,3 +65,17 @@ _g_clear_fd_ignore_error (int *fd_ptr)
 #define g_autofd __attribute__((cleanup(_g_clear_fd_ignore_error)))
 
 #endif
+
+#if !GLIB_CHECK_VERSION(2, 84, 0)
+static inline unsigned int
+backport_steal_handle_id (unsigned int *handle_pointer)
+{
+  unsigned int handle;
+
+  handle = *handle_pointer;
+  *handle_pointer = 0;
+
+  return handle;
+}
+#define g_steal_handle_id(hp) backport_steal_handle_id (hp)
+#endif

--- a/libportal/inputcapture.c
+++ b/libportal/inputcapture.c
@@ -239,8 +239,10 @@ static void create_session (Call *call);
 static void get_zones (Call *call);
 
 static void
-call_dispose (Call *call)
+call_dispose (void *p)
 {
+  Call *call = p;
+
   /* CreateSesssion */
   if (call->parent)
     call->parent->parent_unexport (call->parent);
@@ -271,18 +273,9 @@ call_ref (Call *call)
 }
 
 static inline void
-call_last_unref (void *call)
-{
-  /* Only separated from call_dispose() because g_rc_box_release_full()
-   * wants a GDestroyNotify, and because this is a convenient place to put
-   * life-cycle debugging */
-  call_dispose (call);
-}
-
-static inline void
 call_unref (void *call)
 {
-  g_rc_box_release_full (call, call_last_unref);
+  g_rc_box_release_full (call, call_dispose);
 }
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (Call, call_unref)

--- a/libportal/inputcapture.c
+++ b/libportal/inputcapture.c
@@ -544,6 +544,10 @@ get_zones_done (GDBusConnection *bus,
   guint32 response;
   g_autoptr(GVariant) ret = NULL;
 
+  /* If the Call has already been disposed, we should have unsubscribed
+   * from the Response signal at that time, so we shouldn't get here */
+  g_return_if_fail (G_IS_TASK (call->task));
+
   g_variant_get (parameters, "(u@a{sv})", &response, &ret);
 
   if (response != 0)
@@ -676,6 +680,10 @@ session_created (GDBusConnection *bus,
   Call *call = data;
   guint32 response;
   g_autoptr(GVariant) ret = NULL;
+
+  /* If the Call has already been disposed, we should have unsubscribed
+   * from the Response signal at that time, so we shouldn't get here */
+  g_return_if_fail (G_IS_TASK (call->task));
 
   g_variant_get (parameters, "(u@a{sv})", &response, &ret);
 
@@ -955,6 +963,10 @@ set_pointer_barriers_done (GDBusConnection *bus,
   g_autoptr(GVariant) ret = NULL;
   GVariant *failed = NULL;
   GList *failed_list = NULL;
+
+  /* If the Call has already been disposed, we should have unsubscribed
+   * from the Response signal at that time, so we shouldn't get here */
+  g_return_if_fail (G_IS_TASK (call->task));
 
   g_variant_get (parameters, "(u@a{sv})", &response, &ret);
 

--- a/libportal/inputcapture.c
+++ b/libportal/inputcapture.c
@@ -633,6 +633,8 @@ get_zones_done (GDBusConnection *bus,
     g_task_return_new_error (call->task, G_IO_ERROR, G_IO_ERROR_CANCELLED, "InputCapture GetZones() canceled");
   else if (response == 2)
     g_task_return_new_error (call->task, G_IO_ERROR, G_IO_ERROR_FAILED, "InputCapture GetZones() failed");
+  else if (response != 0)
+    g_task_return_new_error (call->task, G_IO_ERROR, G_IO_ERROR_FAILED, "InputCapture GetZones() unknown response code %d", response);
 
   /* If the Call failed, we can ignore any subsequent method replies */
   if (response != 0)
@@ -699,6 +701,8 @@ session_created (GDBusConnection *bus,
     g_task_return_new_error (call->task, G_IO_ERROR, G_IO_ERROR_CANCELLED, "CreateSession canceled");
   else if (response == 2)
     g_task_return_new_error (call->task, G_IO_ERROR, G_IO_ERROR_FAILED, "CreateSession failed");
+  else if (response != 0)
+    g_task_return_new_error (call->task, G_IO_ERROR, G_IO_ERROR_FAILED, "InputCapture CreateSession() unknown response code %d", response);
 
   /* If the Call failed, we can ignore any subsequent method replies */
   if (response != 0)

--- a/libportal/inputcapture.c
+++ b/libportal/inputcapture.c
@@ -383,6 +383,8 @@ prep_call (Call *call, GDBusSignalCallback callback, GVariantBuilder *options, v
 {
   g_autofree char *token = NULL;
 
+  g_return_if_fail (call->signal_id == 0);
+
   token = g_strdup_printf ("portal%d", g_random_int_range (0, G_MAXINT));
   call->request_path = g_strconcat (REQUEST_PATH_PREFIX, call->portal->sender, "/", token, NULL);
   call->signal_id = g_dbus_connection_signal_subscribe (call->portal->bus,

--- a/libportal/inputcapture.c
+++ b/libportal/inputcapture.c
@@ -619,8 +619,6 @@ get_zones_done (GDBusConnection *bus,
         {
           set_zones (session, zones, zone_set);
           g_task_return_pointer (call->task, g_steal_pointer (&session), g_object_unref);
-          /* Now the Call succeeded, we can ignore any subsequent method replies */
-          call_dispose (call);
         }
       else
         {
@@ -636,8 +634,8 @@ get_zones_done (GDBusConnection *bus,
   else if (response != 0)
     g_task_return_new_error (call->task, G_IO_ERROR, G_IO_ERROR_FAILED, "InputCapture GetZones() unknown response code %d", response);
 
-  /* If the Call failed, we can ignore any subsequent method replies */
-  if (response != 0)
+  /* If the Call succeeded or failed, we can ignore any subsequent method replies */
+  if (g_task_get_completed (call->task))
     call_dispose (call);
 }
 
@@ -705,7 +703,7 @@ session_created (GDBusConnection *bus,
     g_task_return_new_error (call->task, G_IO_ERROR, G_IO_ERROR_FAILED, "InputCapture CreateSession() unknown response code %d", response);
 
   /* If the Call failed, we can ignore any subsequent method replies */
-  if (response != 0)
+  if (g_task_get_completed (call->task))
     call_dispose (call);
 }
 

--- a/libportal/inputcapture.c
+++ b/libportal/inputcapture.c
@@ -523,7 +523,11 @@ get_zones_done (GDBusConnection *bus,
       g_dbus_connection_signal_unsubscribe (call->portal->bus, call->signal_id);
       call->signal_id = 0;
 
-      if (session == NULL)
+      if (session != NULL)
+        {
+          g_object_ref (session);
+        }
+      else
         {
           session = _xdp_input_capture_session_new (call->portal, call->session_path);
           session->signal_ids[SIGNAL_ZONES_CHANGED] =
@@ -579,7 +583,7 @@ get_zones_done (GDBusConnection *bus,
           g_variant_lookup (ret, "zones", "@a(uuii)", &zones))
         {
           set_zones (session, zones, zone_set);
-          g_task_return_pointer (call->task, session, g_object_unref);
+          g_task_return_pointer (call->task, g_steal_pointer (&session), g_object_unref);
         }
       else
         {


### PR DESCRIPTION
Best reviewed commit-by-commit.

* glib-backports: Add a backport of g_steal_handle_id()
    
    This is useful when writing idempotent code to unsubscribe from GDBus
    signals.

* inputcapture: Factor out call_dispose() from call_free()
    
    This makes call_dispose() idempotent, so that it can be called whenever a
    Call has become irrelevant, but without freeing the memory used for the
    Call structure itself, which would leave it as a dangling pointer if it
    is still in use as the user-data of an async call.
    
    This will be used in a subsequent commit to keep the Call alive via a
    circular reference between the GTask and Call while we are still waiting
    for a result, and then break the circular reference with call_dispose()
    when the Call has reached a resolution, either success or failure.

* inputcapture: Reference a pre-existing session where necessary
    
    We're passing the session object to g_task_return_pointer() with
    g_object_unref as the free-function, and that's only correct if we
    previously owned a reference to it. In the case where we created a fresh
    session object, we did own a reference, but in the case where we merely
    retrieved it from call->session, we did not.
    
    This would have led to a use-after-free if it wasn't for the fact that
    we are leaking the Call object (#190), which leaks a reference to the
    session, avoiding the use-after-free via compensating errors. Before we
    can safely fix the leak, we have to reference-count the session correctly.

* inputcapture: Reference-count Call instances
    
    To avoid a use-after-free (#169), we need to make sure that there is
    at least one reference held to the memory used to store the Call struct
    for the duration of each D-Bus method call, so consistently take a new
    ref to the user-data of g_dbus_connection_call(), and release it in
    call_returned().
    
    However, we also need to keep the Call alive for as long as it is
    listening to any D-Bus signals, without introducing a long-term
    circular reference that would make it be leaked indefinitely.
    
    To achieve this, create a temporary circular reference between the Call
    and the GTask, but break it via call_dispose() every time we reach a
    resolution to the task, whether that's success or a failure.
    
    Resolves: https://github.com/flatpak/libportal/issues/169
    Resolves: https://github.com/flatpak/libportal/issues/190

* inputcapture: Assert that we don't prep_call() twice in parallel
    
    If we did, then the second signal subscription would overwrite the first,
    and call_dispose() would no longer unsubscribe the first signal
    subscription, breaking our memory-management assumptions.

* inputcapture: Drop unused userdata parameter to prep_call
    
    Despite its name, this was really a free-function for the GDBus
    signal subscription, which in practice was always NULL.

* inputcapture: Guard against unknown Response codes
    
    If the response code was somehow neither 0, 1 nor 2, we would previously
    have freed the GTask without ever returning a result. Return a failed
    result in this case, mechanically equivalent to response code 2
    ("The user interaction was ended in some other way") but with a
    different error message.

* inputcapture: Consistently end the Call iff the GTask has completed
    
    After the previous commit ensured that the GTask is always given a
    result at all appropriate times, this should not make any practical
    difference.
    
    However, it hopefully makes the intention clearer: after the GTask has
    completed, we always dispose the Call, and if the GTask has not yet
    completed, we never do.

* inputcapture: Assert that we don't receive Response signals after dispose
    
    When the Call object is disposed, it unsubscribes from the Response
    signal before releasing its GTask reference, so it should be impossible
    to get into the Response handler after dispose. Clarify that.