### PR TITLE
Use #pragma once

### DIFF
--- a/libportal/glib-backports.h
+++ b/libportal/glib-backports.h
@@ -17,6 +17,8 @@
  * SPDX-License-Identifier: LGPL-3.0-only
  */
 
+#pragma once
+
 #include <errno.h>
 
 #include <glib/gstdio.h>

--- a/libportal/inputcapture-private.h
+++ b/libportal/inputcapture-private.h
@@ -17,6 +17,8 @@
  * SPDX-License-Identifier: LGPL-3.0-only
  */
 
+#pragma once
+
 #include "inputcapture-pointerbarrier.h"
 #include "inputcapture-zone.h"
 

--- a/portal-test/qt5/portal-test-qt.h
+++ b/portal-test/qt5/portal-test-qt.h
@@ -1,6 +1,4 @@
-
-#ifndef PORTAL_TEST_QT_H
-#define PORTAL_TEST_QT_H
+#pragma once
 
 #include <QMainWindow>
 
@@ -24,5 +22,3 @@ private:
     Ui_PortalTestQt *m_mainWindow;
     XdpPortal *m_portal;
 };
-
-#endif // PORTAL_TEST_QT_H

--- a/portal-test/qt6/portal-test-qt.h
+++ b/portal-test/qt6/portal-test-qt.h
@@ -1,6 +1,4 @@
-
-#ifndef PORTAL_TEST_QT_H
-#define PORTAL_TEST_QT_H
+#pragma once
 
 #include <QMainWindow>
 
@@ -24,5 +22,3 @@ private:
     Ui_PortalTestQt *m_mainWindow;
     XdpPortal *m_portal;
 };
-
-#endif // PORTAL_TEST_QT_H

--- a/tests/qt5/test.h
+++ b/tests/qt5/test.h
@@ -17,8 +17,7 @@
  * SPDX-License-Identifier: LGPL-3.0-only
  */
 
-#ifndef TEST_H
-#define TEST_H
+#pragma once
 
 #include <QObject>
 
@@ -29,5 +28,3 @@ private Q_SLOTS:
     void testFileChooserPortal();
     void testNotificationPortal();
 };
-
-#endif // TEST_H

--- a/tests/qt6/test.h
+++ b/tests/qt6/test.h
@@ -18,8 +18,7 @@
  * SPDX-License-Identifier: LGPL-3.0-only
  */
 
-#ifndef TEST_H
-#define TEST_H
+#pragma once
 
 #include <QObject>
 
@@ -30,5 +29,3 @@ private Q_SLOTS:
     void testFileChooserPortal();
     void testNotificationPortal();
 };
-
-#endif // TEST_H


### PR DESCRIPTION
* Use `#pragma once` in all headers that do not already have guards
    
    It's easier to deal with header files when it's unconditionally safe to
    include the same header more than once.
    
    In particular the absence of `#pragma once` in `glib-backports.h` caused
    a build failure in #191, but only for older GLib releases.

* Qt: Use `#pragma once` instead of traditional single-inclusion guards
    
    This is slightly more efficient, and removes any concerns about whether
    we have reused the same macro name for two different headers.