### PR TITLE
tests/notification: Use GioUnix to get InputStream

### DIFF
--- a/libportal/meson.build
+++ b/libportal/meson.build
@@ -70,7 +70,7 @@ src = [
   generated_files,
 ]
 
-gio_dep = dependency('gio-2.0', version: '>= 2.72')
+gio_dep = dependency('gio-2.0', version: '>= 2.80')
 gio_unix_dep = dependency('gio-unix-2.0')
 
 install_headers(public_headers, subdir: 'libportal')

--- a/tests/pyportaltest/test_notification.py
+++ b/tests/pyportaltest/test_notification.py
@@ -8,7 +8,7 @@ import gi
 import logging
 
 gi.require_version("Xdp", "1.0")
-from gi.repository import GLib, Gio, Xdp
+from gi.repository import GLib, Gio, GioUnix, Xdp
 
 logger = logging.getLogger(__name__)
 
@@ -96,7 +96,7 @@ class TestNotification(PortalTest):
         assert dict(notification) == notification_to_set_dict
         (icon_type, handle) = icon
         assert icon_type == "file-descriptor"
-        input_stream = Gio.UnixInputStream.new(handle.take(), True)
+        input_stream = GioUnix.InputStream.new(handle.take(), True)
 
         res_bytes = input_stream.read_bytes(bytes.get_size(), None)
         assert res_bytes.equal(bytes)
@@ -128,7 +128,7 @@ class TestNotification(PortalTest):
         assert dict(notification) == notification_to_set_dict
         (icon_type, handle) = icon
         assert icon_type == "file-descriptor"
-        input_stream = Gio.UnixInputStream.new(handle.take(), True)
+        input_stream = GioUnix.InputStream.new(handle.take(), True)
 
         res_bytes = input_stream.read_bytes(bytes.get_size(), None)
         assert res_bytes.equal(bytes)
@@ -183,7 +183,7 @@ class TestNotification(PortalTest):
         assert dict(notification) == notification_to_set_dict
         (sound_type, handle) = sound
         assert sound_type == "file-descriptor"
-        input_stream = Gio.UnixInputStream.new(handle.take(), True)
+        input_stream = GioUnix.InputStream.new(handle.take(), True)
 
         res_bytes = input_stream.read_bytes(bytes.get_size(), None)
         assert res_bytes.equal(bytes)
@@ -216,7 +216,7 @@ class TestNotification(PortalTest):
         assert dict(notification) == notification_to_set_dict
         (sound_type, handle) = sound_out
         assert sound_type == "file-descriptor"
-        input_stream = Gio.UnixInputStream.new(handle.take(), True)
+        input_stream = GioUnix.InputStream.new(handle.take(), True)
 
         res_bytes = input_stream.read_bytes(bytes.get_size(), None)
         assert res_bytes.equal(bytes)


### PR DESCRIPTION
Gio.UnixInputStream is deprecated since GLib 2.80 (and even broken in 2.86), so use the platform-implementation instead.

See: https://gitlab.gnome.org/GNOME/pygobject/-/merge_requests/452