### PR TITLE
build-aux: Use GNOME 49 runtime for Gtk 3 example, too

### DIFF
--- a/build-aux/org.gnome.PortalTest.Gtk3.json
+++ b/build-aux/org.gnome.PortalTest.Gtk3.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.PortalTest.Gtk3",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "47",
+    "runtime-version": "49",
     "sdk": "org.gnome.Sdk",
     "command": "portal-test-gtk3",
     "finish-args": [


### PR DESCRIPTION
---

@TheEvilSkeleton, was there a reason you didn't do this already in #206?