### PR TITLE
Update minimum required Meson version to 1.9.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('libportal','c',
         version: '0.9.2',
         default_options: ['warning_level=2'],
-        meson_version: '>= 0.55.0')
+        meson_version: '>= 1.9.0')
 
 cc = meson.get_compiler('c')
 cflags = [


### PR DESCRIPTION
<img width="1377" height="89" alt="image" src="https://github.com/user-attachments/assets/a8957731-c49d-44e0-a0b7-7fd62d0b3565" />

references:
https://mesonbuild.com/Release-notes-for-1-9-0.html#pkgconfiggenerate-supports-internal-dependencies-in-requires