### PR TITLE
 update Ci to newer OS versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
             qt6-base-private-dev \
             valac
       - name: Check out libportal
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Fix Git ownership
         run: |
           echo $GITHUB_WORKSPACE
@@ -65,7 +65,7 @@ jobs:
         working-directory: _build
         run: meson dist
       - name: Upload test logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: success() || failure()
         with:
           name: test logs (ubuntu ${{ matrix.ubuntu-version }} ${{ matrix.compiler }})
@@ -124,7 +124,7 @@ jobs:
         working-directory: _build
         run: meson dist
       - name: Upload test logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: success() || failure()
         with:
           name: test logs (fedora ${{ matrix.fedora-version }} ${{ matrix.compiler }})
@@ -151,7 +151,7 @@ jobs:
           curl https://gitlab.freedesktop.org/hadess/check-abi/-/raw/main/contrib/check-abi-fedora.sh | bash
           rm -rf check-abi/
       - name: Check out libportal
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Work around git safe directory check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     container: ubuntu:${{ matrix.ubuntu-version }}
     strategy:
       matrix:
-        ubuntu-version: ['22.04', '24.04']
+        ubuntu-version: ['24.04', '26.04']
         compiler: ['gcc', 'clang']
 
     env:
@@ -82,7 +82,7 @@ jobs:
     container: fedora:${{ matrix.fedora-version }}
     strategy:
       matrix:
-        fedora-version: ['39', '40']
+        fedora-version: ['43', '44']
         compiler: ['gcc', 'clang']
 
     env:

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -19,7 +19,7 @@ jobs:
       options: --privileged
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Build GTK3 portal test
         uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v6
@@ -36,7 +36,7 @@ jobs:
       options: --privileged
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Build GTK4 portal test
         uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v6
@@ -53,7 +53,7 @@ jobs:
       options: --privileged
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Build Qt5 portal test
         uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v6
@@ -70,7 +70,7 @@ jobs:
       options: --privileged
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Build Qt6 portal test
         uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v6

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,7 +30,7 @@ jobs:
             python3-dbusmock
 
       - name: Check out libportal
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure libportal
         run: meson setup --prefix=/usr builddir -Dtests=false -Dvapi=false
@@ -44,7 +44,7 @@ jobs:
           mv ./libportal-1 ../../_site
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
 
   # Deployment job
   deploy:
@@ -58,4 +58,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
 - Update the Ci to use Ubuntu 24.04 and Ubuntu 26.04
 - Update the Ci to use Fedora 43 and Fedora 44

- update Stale actions  needed when node 20 is turned off
  -  checkout to v6
  -  upload action v7
  -  pages deploy / pages upload v5